### PR TITLE
[CT-17] 예외를 값으로 리턴, UseCase를 Flow로 통일

### DIFF
--- a/domain/src/main/java/com/yessorae/domain/common/Result.kt
+++ b/domain/src/main/java/com/yessorae/domain/common/Result.kt
@@ -1,0 +1,49 @@
+package com.yessorae.domain.common
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEmpty
+import kotlinx.coroutines.flow.onStart
+
+sealed class Result<out T> {
+    object Loading : Result<Nothing>()
+    data class Success<T>(val data: T) : Result<T>()
+    data class Failure(val throwable: Throwable) : Result<Nothing>()
+}
+
+fun Flow<Result<Unit>>.delegateEmptyResultFlow(): Flow<Result<Unit>> {
+    return this
+        .emitLoadingResultOnStart()
+        .emitFailureResultOnCatch()
+        .emitSuccessResultOnEmpty()
+}
+
+fun <T> Flow<T>.delegateValueResultFlow(): Flow<Result<T>> {
+    return this
+        .mapToSuccessResult()
+        .emitLoadingResultOnStart()
+        .emitFailureResultOnCatch()
+}
+
+private fun <T> Flow<T>.mapToSuccessResult(): Flow<Result<T>> {
+    return this.map { Result.Success(data = it) }
+}
+
+private fun Flow<Result<Unit>>.emitSuccessResultOnEmpty(): Flow<Result<Unit>> {
+    return this.onEmpty {
+        emit(Result.Success(data = Unit))
+    }
+}
+
+private fun <T> Flow<Result<T>>.emitLoadingResultOnStart(): Flow<Result<T>> {
+    return this.onStart {
+        emit(Result.Loading)
+    }
+}
+
+private fun <T> Flow<Result<T>>.emitFailureResultOnCatch(): Flow<Result<T>> {
+    return this.catch { throwable ->
+        emit(Result.Failure(throwable = throwable))
+    }
+}

--- a/domain/src/main/java/com/yessorae/domain/exception/ChartGameException.kt
+++ b/domain/src/main/java/com/yessorae/domain/exception/ChartGameException.kt
@@ -12,4 +12,8 @@ sealed class ChartGameException(override val message: String = "") : Exception(m
     data class CanNotChangeTradeException(
         override val message: String
     ) : ChartGameException(message = message)
+
+    data class UnknownException(
+        val sight: String
+    ) : ChartGameException(message = "occurred at $sight}")
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/ChangeChartUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/ChangeChartUseCase.kt
@@ -5,9 +5,9 @@ import com.yessorae.domain.common.delegateEmptyResultFlow
 import com.yessorae.domain.exception.ChartGameException
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.ChartRepository
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import javax.inject.Inject
 
 class ChangeChartUseCase @Inject constructor(
     private val chartRepository: ChartRepository,

--- a/domain/src/main/java/com/yessorae/domain/usecase/ChangeChartUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/ChangeChartUseCase.kt
@@ -1,30 +1,32 @@
 package com.yessorae.domain.usecase
 
+import com.yessorae.domain.common.Result
+import com.yessorae.domain.common.delegateEmptyResultFlow
 import com.yessorae.domain.exception.ChartGameException
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.ChartRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class ChangeChartUseCase @Inject constructor(
     private val chartRepository: ChartRepository,
     private val chartGameRepository: ChartGameRepository
 ) {
-    suspend operator fun invoke(gameId: Long): Result<Unit> {
-        val oldChartGame = chartGameRepository.fetchChartGame(gameId = gameId)
+    suspend operator fun invoke(gameId: Long): Flow<Result<Unit>> =
+        flow<Nothing> {
+            val oldChartGame = chartGameRepository.fetchChartGame(gameId = gameId)
 
-        if (oldChartGame.isGameEnd) {
-            return Result.failure(
-                ChartGameException.CanNotChangeChartException(
+            if (oldChartGame.isGameEnd) {
+                throw ChartGameException.CanNotChangeChartException(
                     message = "can't change chart because game has been end"
                 )
-            )
-        }
+            }
 
-        chartGameRepository.updateChartGame(
-            chartGame = oldChartGame.copyFrom(
-                newChart = chartRepository.fetchNewChartRandomly()
+            chartGameRepository.updateChartGame(
+                chartGame = oldChartGame.copyFrom(
+                    newChart = chartRepository.fetchNewChartRandomly()
+                )
             )
-        )
-        return Result.success(value = Unit)
-    }
+        }.delegateEmptyResultFlow()
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/QuitChartGameUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/QuitChartGameUseCase.kt
@@ -1,13 +1,18 @@
 package com.yessorae.domain.usecase
 
+import com.yessorae.domain.common.Result
+import com.yessorae.domain.common.delegateEmptyResultFlow
 import com.yessorae.domain.repository.ChartGameRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class QuitChartGameUseCase @Inject constructor(
     private val chartGameRepository: ChartGameRepository
 ) {
-    suspend operator fun invoke(gameId: Long) {
-        val oldChartGame = chartGameRepository.fetchChartGame(gameId = gameId)
-        chartGameRepository.updateChartGame(chartGame = oldChartGame.createFromQuit())
-    }
+    suspend operator fun invoke(gameId: Long): Flow<Result<Unit>> =
+        flow<Nothing> {
+            val oldChartGame = chartGameRepository.fetchChartGame(gameId = gameId)
+            chartGameRepository.updateChartGame(chartGame = oldChartGame.createFromQuit())
+        }.delegateEmptyResultFlow()
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/QuitChartGameUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/QuitChartGameUseCase.kt
@@ -3,9 +3,9 @@ package com.yessorae.domain.usecase
 import com.yessorae.domain.common.Result
 import com.yessorae.domain.common.delegateEmptyResultFlow
 import com.yessorae.domain.repository.ChartGameRepository
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import javax.inject.Inject
 
 class QuitChartGameUseCase @Inject constructor(
     private val chartGameRepository: ChartGameRepository

--- a/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameUseCase.kt
@@ -6,8 +6,8 @@ import com.yessorae.domain.entity.ChartGame
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.ChartRepository
 import com.yessorae.domain.repository.UserRepository
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 class SubscribeChartGameUseCase @Inject constructor(
     private val userRepository: UserRepository,

--- a/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameUseCase.kt
@@ -1,31 +1,36 @@
 package com.yessorae.domain.usecase
 
+import com.yessorae.domain.common.Result
+import com.yessorae.domain.common.delegateValueResultFlow
 import com.yessorae.domain.entity.ChartGame
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.ChartRepository
 import com.yessorae.domain.repository.UserRepository
-import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
 
 class SubscribeChartGameUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val chartRepository: ChartRepository,
     private val chartGameRepository: ChartGameRepository
 ) {
-    suspend operator fun invoke(gameId: Long?): Flow<ChartGame> {
+    suspend operator fun invoke(gameId: Long?): Flow<Result<ChartGame>> {
         if (gameId == null) {
-            val newGameId =
-                chartGameRepository.saveChartGame(
-                    chartGame =
-                    ChartGame.new(
-                        chart = chartRepository.fetchNewChartRandomly(),
-                        totalTurn = userRepository.fetchTotalTurnConfig(),
-                        startBalance = userRepository.fetchCurrentBalance()
-                    )
+            val newGameId = chartGameRepository.saveChartGame(
+                chartGame = ChartGame.new(
+                    chart = chartRepository.fetchNewChartRandomly(),
+                    totalTurn = userRepository.fetchTotalTurnConfig(),
+                    startBalance = userRepository.fetchCurrentBalance()
                 )
-            return chartGameRepository.fetchChartFlowStream(gameId = newGameId)
+            )
+
+            return chartGameRepository
+                .fetchChartFlowStream(gameId = newGameId)
+                .delegateValueResultFlow()
         }
 
-        return chartGameRepository.fetchChartFlowStream(gameId = gameId)
+        return chartGameRepository
+            .fetchChartFlowStream(gameId = gameId)
+            .delegateValueResultFlow()
     }
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/TradeStockUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/TradeStockUseCase.kt
@@ -1,11 +1,15 @@
 package com.yessorae.domain.usecase
 
+import com.yessorae.domain.common.Result
+import com.yessorae.domain.common.delegateEmptyResultFlow
 import com.yessorae.domain.entity.trade.Trade
 import com.yessorae.domain.entity.trade.TradeType
 import com.yessorae.domain.entity.value.Money
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.TradeRepository
 import com.yessorae.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class TradeStockUseCase @Inject constructor(
@@ -20,9 +24,9 @@ class TradeStockUseCase @Inject constructor(
         count: Int,
         turn: Int,
         type: TradeType
-    ) {
-        val trade =
-            Trade.new(
+    ): Flow<Result<Unit>> =
+        flow<Nothing> {
+            val trade = Trade.new(
                 gameId = gameId,
                 ownedAverageStockPrice = ownedAverageStockPrice,
                 stockPrice = stockPrice,
@@ -32,14 +36,14 @@ class TradeStockUseCase @Inject constructor(
                 commissionRate = userRepository.fetchCommissionRateConfig()
             )
 
-        tradeRepository.saveTradeHistory(trade = trade)
+            tradeRepository.saveTradeHistory(trade = trade)
 
-        chartGameRepository.updateChartGame(
-            chartGame = chartGameRepository.fetchChartGame(
-                gameId = gameId
-            ).copyFrom(
-                newTrade = trade
+            chartGameRepository.updateChartGame(
+                chartGame = chartGameRepository.fetchChartGame(
+                    gameId = gameId
+                ).copyFrom(
+                    newTrade = trade
+                )
             )
-        )
-    }
+        }.delegateEmptyResultFlow()
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/TradeStockUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/TradeStockUseCase.kt
@@ -8,9 +8,9 @@ import com.yessorae.domain.entity.value.Money
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.TradeRepository
 import com.yessorae.domain.repository.UserRepository
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import javax.inject.Inject
 
 class TradeStockUseCase @Inject constructor(
     private val chartGameRepository: ChartGameRepository,

--- a/domain/src/main/java/com/yessorae/domain/usecase/UpdateNextTickUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/UpdateNextTickUseCase.kt
@@ -4,9 +4,9 @@ import com.yessorae.domain.common.Result
 import com.yessorae.domain.common.delegateEmptyResultFlow
 import com.yessorae.domain.exception.ChartGameException
 import com.yessorae.domain.repository.ChartGameRepository
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import javax.inject.Inject
 
 class UpdateNextTickUseCase @Inject constructor(
     private val chartGameRepository: ChartGameRepository

--- a/domain/src/main/java/com/yessorae/domain/usecase/UpdateNextTickUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/UpdateNextTickUseCase.kt
@@ -1,25 +1,26 @@
 package com.yessorae.domain.usecase
 
+import com.yessorae.domain.common.Result
+import com.yessorae.domain.common.delegateEmptyResultFlow
 import com.yessorae.domain.exception.ChartGameException
 import com.yessorae.domain.repository.ChartGameRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class UpdateNextTickUseCase @Inject constructor(
     private val chartGameRepository: ChartGameRepository
 ) {
-    suspend operator fun invoke(gameId: Long): Result<Unit> {
-        val newChartGame = chartGameRepository.fetchChartGame(gameId = gameId).getNextTurn()
+    suspend operator fun invoke(gameId: Long): Flow<Result<Unit>> =
+        flow<Nothing> {
+            val newChartGame = chartGameRepository.fetchChartGame(gameId = gameId).getNextTurn()
 
-        if (newChartGame.isGameEnd) {
-            return Result.failure(
-                ChartGameException.CanNotUpdateNextTickException(
+            if (newChartGame.isGameEnd) {
+                throw ChartGameException.CanNotUpdateNextTickException(
                     message = "can't update next tick because game has been end"
                 )
-            )
-        }
+            }
 
-        chartGameRepository.updateChartGame(chartGame = newChartGame)
-
-        return Result.success(Unit)
-    }
+            chartGameRepository.updateChartGame(chartGame = newChartGame)
+        }.delegateEmptyResultFlow()
 }


### PR DESCRIPTION
close #17 
# Purpose
- 예외를 값으로 반환하여 흐름을 추적하기 쉽게 만든다.
- try-catch로하려니까 연속적으로 불러야할 때 연속적인 들여쓰기 방지. 다른 Flow와의 호환되게 처리. (Flow로 통일되면 ViewModel에서 await 처럼 combine이나 zip으로 동시에 처리할 수도 있고 flatMapOOO을 써서 suspend처럼 동기적으로 작성할 수도 있어서 코드 들여쓰기를 많이 하지 않고 연쇄함수로 작성할 수 있을 것 같습니다.)

리뷰 반영을 늦게하여, 긴급 PR로 대체합니다.