### PR TITLE
[CT-7] 게임 내역 확인 기능

### DIFF
--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -12,7 +12,7 @@ object Dependency {
             "org.jetbrains.kotlinx:kotlinx-serialization-json:${Version.KOTOIN_SERIALIZATION_JSON}"
 
         const val PAGING_RUNTIME = "androidx.paging:paging-runtime:${Version.PAGING}"
-        const val PAGING_COMMON = "androidx.paging:paging-common-jvm:${Version.PAGING}"
+        const val PAGING_COMMON = "androidx.paging:paging-common:${Version.PAGING}"
 
         object Version {
             const val HILT = "2.44"
@@ -44,6 +44,7 @@ object Dependency {
         const val ROOM_COMPILER = "androidx.room:room-compiler:${Version.ROOM}"
         const val ROOM_KAPT = "androidx.room:room-compiler:${Version.ROOM}"
         const val ROOM_COROUTINE = "androidx.room:room-ktx:${Version.ROOM}"
+        const val ROOM_PAGING = "androidx.room:room-paging:${Version.ROOM}"
         const val RETROFIT = "com.squareup.retrofit2:retrofit:${Version.RETROFIT}"
         const val RETROFIT_GSON_CONVERTER =
             "com.squareup.retrofit2:converter-kotlinx-serialization:${Version.RETROFIT}"

--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -11,6 +11,9 @@ object Dependency {
         const val KOTOIN_SERIALIZATION_JSON =
             "org.jetbrains.kotlinx:kotlinx-serialization-json:${Version.KOTOIN_SERIALIZATION_JSON}"
 
+        const val PAGING_RUNTIME = "androidx.paging:paging-runtime:${Version.PAGING}"
+        const val PAGING_COMMON = "androidx.paging:paging-common-jvm:${Version.PAGING}"
+
         object Version {
             const val HILT = "2.44"
             const val ANDROIDX_CORE = "1.9.0"
@@ -19,6 +22,8 @@ object Dependency {
 
             // 1.5.0 이 Kotlin 버전 1.8.10 을 디폴트로 사용
             const val KOTOIN_SERIALIZATION_JSON = "1.5.0"
+
+            const val PAGING = "3.3.0"
         }
     }
 
@@ -75,6 +80,7 @@ object Dependency {
         const val UI_TOOLING_PREVIEW = "androidx.compose.ui:ui-tooling-preview"
         const val JUNIT = "androidx.compose.ui:ui-test-junit4"
         const val UI_TEST_MANIFEST = "androidx.compose.ui:ui-test-manifest"
+        const val PAGING_COMPOSE = "androidx.paging:paging-compose:${Common.Version.PAGING}"
 
         object Version {
             const val BOM = "2023.03.00"

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     annotationProcessor(Dependency.Data.ROOM_COMPILER)
     kapt(Dependency.Data.ROOM_KAPT)
     implementation(Dependency.Data.ROOM_COROUTINE)
+    implementation(Dependency.Data.ROOM_PAGING)
 
     implementation(Dependency.Data.RETROFIT)
     implementation(Dependency.Data.RETROFIT_GSON_CONVERTER)
@@ -77,7 +78,7 @@ dependencies {
 
     implementation(Dependency.Common.KOTOIN_SERIALIZATION_JSON)
 
-    implementation(Dependency.Common.PAGING_RUNTIME)
+//    implementation(Dependency.Common.PAGING_RUNTIME)
 
     testImplementation(Dependency.Common.JUNIT)
     androidTestImplementation(Dependency.Common.JUNIT_EXT)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -78,8 +78,6 @@ dependencies {
 
     implementation(Dependency.Common.KOTOIN_SERIALIZATION_JSON)
 
-//    implementation(Dependency.Common.PAGING_RUNTIME)
-
     testImplementation(Dependency.Common.JUNIT)
     androidTestImplementation(Dependency.Common.JUNIT_EXT)
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -77,6 +77,8 @@ dependencies {
 
     implementation(Dependency.Common.KOTOIN_SERIALIZATION_JSON)
 
+    implementation(Dependency.Common.PAGING_RUNTIME)
+
     testImplementation(Dependency.Common.JUNIT)
     androidTestImplementation(Dependency.Common.JUNIT_EXT)
 }

--- a/data/src/main/java/com/yessorae/data/source/ChartTrainerLocalDBDataSource.kt
+++ b/data/src/main/java/com/yessorae/data/source/ChartTrainerLocalDBDataSource.kt
@@ -1,5 +1,6 @@
 package com.yessorae.data.source
 
+import androidx.paging.PagingSource
 import com.yessorae.data.source.local.database.model.ChartEntity
 import com.yessorae.data.source.local.database.model.ChartGameEntity
 import com.yessorae.data.source.local.database.model.TickEntity
@@ -9,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 // Repository 가 Dao 에 직접적으로 의존하지 않는 것에 중점을 둠
 interface ChartTrainerLocalDBDataSource {
     fun getChartGameAsFlow(id: Long): Flow<ChartGameEntity>
+    fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity>
     fun getTradesAsFlow(gameId: Long): Flow<List<TradeEntity>>
     suspend fun getChartGame(id: Long): ChartGameEntity
     suspend fun getTrades(gameId: Long): List<TradeEntity>

--- a/data/src/main/java/com/yessorae/data/source/local/database/ChartTrainerLocalDBDataSourceImpl.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/ChartTrainerLocalDBDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.yessorae.data.source.local.database
 
+import androidx.paging.PagingSource
 import com.yessorae.data.source.ChartTrainerLocalDBDataSource
 import com.yessorae.data.source.local.database.dao.ChartDao
 import com.yessorae.data.source.local.database.dao.ChartGameDao
@@ -20,6 +21,9 @@ class ChartTrainerLocalDBDataSourceImpl @Inject constructor(
 ) : ChartTrainerLocalDBDataSource {
     override fun getChartGameAsFlow(id: Long): Flow<ChartGameEntity> =
         chartGameDao.getChartGameAsFlow(id = id)
+
+    override fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity> =
+        chartGameDao.getChartGamePagingSource()
 
     override fun getTradesAsFlow(gameId: Long): Flow<List<TradeEntity>> =
         tradeDao.getTradesAsFlow(gameId = gameId)

--- a/data/src/main/java/com/yessorae/data/source/local/database/dao/ChartGameDao.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/dao/ChartGameDao.kt
@@ -1,5 +1,6 @@
 package com.yessorae.data.source.local.database.dao
 
+import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Query
 import com.yessorae.data.source.local.database.model.ChartGameEntity
@@ -20,4 +21,11 @@ interface ChartGameDao : BaseDao<ChartGameEntity> {
         """
     )
     suspend fun getChartGame(id: Long): ChartGameEntity
+
+    @Query(
+        """
+            SELECT * from ${ChartGameEntity.NAME}
+        """
+    )
+    fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity>
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
     implementation(Dependency.PlatformIndependent.JAVAX_INJECT)
     implementation(Dependency.PlatformIndependent.KOTLINX_COROUTINSE)
     implementation(Dependency.Common.KOTOIN_SERIALIZATION_JSON)
+    implementation(Dependency.Common.PAGING_COMMON)
 }

--- a/domain/src/main/java/com/yessorae/domain/repository/ChartGameRepository.kt
+++ b/domain/src/main/java/com/yessorae/domain/repository/ChartGameRepository.kt
@@ -1,5 +1,7 @@
 package com.yessorae.domain.repository
 
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import com.yessorae.domain.entity.ChartGame
 import kotlinx.coroutines.flow.Flow
 
@@ -7,6 +9,8 @@ interface ChartGameRepository {
     suspend fun createNewChartGame(chartGame: ChartGame): Long
 
     fun fetchChartGameFlow(gameId: Long): Flow<ChartGame>
+
+    fun fetchPagedChartGameFlow(pagingConfig: PagingConfig): Flow<PagingData<ChartGame>>
 
     suspend fun fetchChartGame(gameId: Long): ChartGame
 

--- a/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameHistoryUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameHistoryUseCase.kt
@@ -1,0 +1,26 @@
+package com.yessorae.domain.usecase
+
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.yessorae.domain.entity.ChartGame
+import com.yessorae.domain.repository.ChartGameRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+class SubscribeChartGameHistoryUseCase @Inject constructor(
+    private val chartGameRepository: ChartGameRepository
+) {
+    operator fun invoke(): Flow<PagingData<ChartGame>> {
+        return chartGameRepository.fetchPagedChartGameFlow(
+            pagingConfig = PagingConfig(
+                pageSize = PAGE_SIZE,
+                initialLoadSize = PAGE_SIZE,
+                enablePlaceholders = false
+            )
+        )
+    }
+
+    companion object {
+        const val PAGE_SIZE = 20
+    }
+}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -38,6 +38,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -74,6 +74,10 @@ dependencies {
     implementation(Dependency.Common.ANDROIDX_CORE)
     testImplementation(Dependency.Common.JUNIT)
     androidTestImplementation(Dependency.Common.JUNIT_EXT)
+
+    implementation(Dependency.Common.PAGING_RUNTIME)
+    implementation(Dependency.Presentation.PAGING_COMPOSE)
+
 }
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -78,7 +78,6 @@ dependencies {
 
     implementation(Dependency.Common.PAGING_RUNTIME)
     implementation(Dependency.Presentation.PAGING_COMPOSE)
-
 }
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {

--- a/presentation/src/main/java/com/yessorae/presentation/ui/ChartTrainerNavHost.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/ChartTrainerNavHost.kt
@@ -6,6 +6,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.yessorae.presentation.ui.screen.chartgame.chartGameScreen
 import com.yessorae.presentation.ui.screen.chartgame.navigateToChartGameScreen
+import com.yessorae.presentation.ui.screen.chartgamehistory.chartGameHistoryScreen
+import com.yessorae.presentation.ui.screen.chartgamehistory.navigateToChartGameHistoryScreen
 import com.yessorae.presentation.ui.screen.home.HOME_ROUTE
 import com.yessorae.presentation.ui.screen.home.homeScreen
 import com.yessorae.presentation.ui.screen.tradehistory.navigateToTradeHistoryScreen
@@ -26,10 +28,20 @@ fun ChartTrainerNavHost(
         homeScreen(
             navigateToChartGame = { chartGameId: Long? ->
                 navController.navigateToChartGameScreen(chartGameId = chartGameId)
+            },
+            navigateToChartGameHistory = {
+                navController.navigateToChartGameHistoryScreen()
             }
         )
 
         chartGameScreen(
+            navigateToBack = navController::popBackStack,
+            navigateToTradeHistory = { chartGameId: Long ->
+                navController.navigateToTradeHistoryScreen(chartGameId = chartGameId)
+            }
+        )
+
+        chartGameHistoryScreen(
             navigateToBack = navController::popBackStack,
             navigateToTradeHistory = { chartGameId: Long ->
                 navController.navigateToTradeHistoryScreen(chartGameId = chartGameId)

--- a/presentation/src/main/java/com/yessorae/presentation/ui/designsystem/util/ChartTrainerIcons.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/designsystem/util/ChartTrainerIcons.kt
@@ -2,6 +2,8 @@ package com.yessorae.presentation.ui.designsystem.util
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.rounded.ExitToApp
 import androidx.compose.material.icons.automirrored.rounded.List
 import androidx.compose.material.icons.filled.Check
@@ -14,9 +16,12 @@ object ChartTrainerIcons {
     val ChangeChart = Icons.Rounded.Refresh
     val Exit = Icons.AutoMirrored.Rounded.ExitToApp
     val TradeList = Icons.AutoMirrored.Rounded.List
+    val ChartGameList = Icons.AutoMirrored.Rounded.List
     val NextTick = Icons.Default.PlayArrow
     val Delete = Icons.AutoMirrored.Filled.ArrowBack
     val OptionArrow = Icons.Default.KeyboardArrowDown
     val Selected = Icons.Default.Check
     val Close = Icons.Default.Close
+    val NavigateArrow = Icons.AutoMirrored.Filled.KeyboardArrowRight
+    val Back = Icons.AutoMirrored.Filled.KeyboardArrowLeft
 }

--- a/presentation/src/main/java/com/yessorae/presentation/ui/designsystem/util/DisplayTextProvider.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/designsystem/util/DisplayTextProvider.kt
@@ -9,6 +9,10 @@ import com.yessorae.domain.entity.value.Money
 import com.yessorae.presentation.R
 import com.yessorae.presentation.ui.designsystem.theme.StockDownColor
 import com.yessorae.presentation.ui.designsystem.theme.StockUpColor
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
 import kotlin.math.absoluteValue
 
 // TODO::LATER TickUnit 확장함수로 가독성 향상, 파일이름 적절하게 변경
@@ -34,5 +38,19 @@ fun TradeType.asColor(): Color =
 
 fun Money.asDefaultDisplayText(): String = "%.2f".format(value)
 
+fun Money.asDisplayTotalProfit(): String =
+    (if (value > 0.0) "+" else "-") + "%.2f".format(value.absoluteValue)
+
 fun Double.asSignedDisplayText(): String =
     (if (this > 0f) "+" else "-") + "%.2f".format(this.absoluteValue)
+
+fun getDisplayDateRangeText(
+    startDate: LocalDateTime?,
+    endDate: LocalDateTime?
+): String {
+    val formatter = DateTimeFormatter
+        .ofLocalizedDate(FormatStyle.SHORT)
+        .localizedBy(Locale.getDefault())
+
+    return "${startDate?.format(formatter) ?: ""} - ${endDate?.format(formatter) ?: ""}"
+}

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryNavigation.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryNavigation.kt
@@ -1,0 +1,29 @@
+package com.yessorae.presentation.ui.screen.chartgamehistory
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+
+const val CHART_GAME_HISTORY_ROUTE = "chart_game_history_route"
+
+fun NavController.navigateToChartGameHistoryScreen(navOptions: NavOptions? = null) {
+    this.navigate(
+        route = CHART_GAME_HISTORY_ROUTE,
+        navOptions = navOptions
+    )
+}
+
+fun NavGraphBuilder.chartGameHistoryScreen(
+    navigateToBack: () -> Unit,
+    navigateToTradeHistory: (Long) -> Unit
+) {
+    composable(
+        route = CHART_GAME_HISTORY_ROUTE
+    ) {
+        ChartGameHistoryRoute(
+            navigateToBack = navigateToBack,
+            navigateToTradeHistory = navigateToTradeHistory
+        )
+    }
+}

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryScreen.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryScreen.kt
@@ -1,0 +1,143 @@
+package com.yessorae.presentation.ui.screen.chartgamehistory
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.yessorae.presentation.R
+import com.yessorae.presentation.ui.designsystem.component.DefaultIconButton
+import com.yessorae.presentation.ui.designsystem.util.ChartTrainerIcons
+import com.yessorae.presentation.ui.screen.chartgamehistory.component.ChartGameHistoryListItem
+import com.yessorae.presentation.ui.screen.chartgamehistory.model.ChartGameHistoryScreenEvent
+import com.yessorae.presentation.ui.screen.chartgamehistory.model.ChartGameHistoryUserAction
+import com.yessorae.presentation.ui.screen.chartgamehistory.model.GameHistoryItem
+import kotlinx.coroutines.flow.SharedFlow
+
+@Composable
+fun ChartGameHistoryRoute(
+    viewModel: ChartGameHistoryViewModel = hiltViewModel(),
+    navigateToBack: () -> Unit,
+    navigateToTradeHistory: (chartGameId: Long) -> Unit
+) {
+    val pagedChartGame = viewModel.pagedChartGameFlow.collectAsLazyPagingItems()
+
+    ChartGameHistoryScreenEventHandler(
+        screenEvent = viewModel.screenEvent,
+        navigateToBack = navigateToBack,
+        navigateToTradeHistory = navigateToTradeHistory
+    )
+
+    ChartGameHistoryScreen(
+        pagedChartGame = pagedChartGame,
+        handleUserAction = viewModel::handleUserAction
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ChartGameHistoryScreen(
+    pagedChartGame: LazyPagingItems<GameHistoryItem>,
+    handleUserAction: (ChartGameHistoryUserAction) -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(id = R.string.chart_game_history_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    DefaultIconButton(
+                        imageVector = ChartTrainerIcons.Back,
+                        onClick = {
+                            handleUserAction(ChartGameHistoryUserAction.ClickBack)
+                        }
+                    )
+                }
+            )
+        },
+        modifier = Modifier.fillMaxSize()
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .padding(paddingValues = paddingValues)
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            when (pagedChartGame.loadState.refresh) {
+                is LoadState.Loading -> {
+                    CircularProgressIndicator()
+                }
+
+                is LoadState.Error -> {
+                    Text(
+                        text = stringResource(id = R.string.common_error_toast),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.displayMedium
+                    )
+                }
+
+                is LoadState.NotLoading -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(pagedChartGame.itemCount) { index ->
+                            pagedChartGame[index]?.let { item ->
+                                ChartGameHistoryListItem(
+                                    item = item,
+                                    onClick = {
+                                        handleUserAction(
+                                            ChartGameHistoryUserAction.ClickChartGameHistory(
+                                                chartGameId = item.id
+                                            )
+                                        )
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChartGameHistoryScreenEventHandler(
+    screenEvent: SharedFlow<ChartGameHistoryScreenEvent>,
+    navigateToBack: () -> Unit,
+    navigateToTradeHistory: (chartGameId: Long) -> Unit
+) {
+    LaunchedEffect(key1 = Unit) {
+        screenEvent.collect { event ->
+            when (event) {
+                is ChartGameHistoryScreenEvent.NavigateToTradeHistory -> {
+                    navigateToTradeHistory(event.chartGameId)
+                }
+
+                is ChartGameHistoryScreenEvent.NavigateToBack -> {
+                    navigateToBack()
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryViewModel.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryViewModel.kt
@@ -1,0 +1,74 @@
+package com.yessorae.presentation.ui.screen.chartgamehistory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
+import androidx.paging.map
+import com.yessorae.domain.usecase.SubscribeChartGameHistoryUseCase
+import com.yessorae.presentation.ui.screen.chartgamehistory.model.ChartGameHistoryScreenEvent
+import com.yessorae.presentation.ui.screen.chartgamehistory.model.ChartGameHistoryUserAction
+import com.yessorae.presentation.ui.screen.chartgamehistory.model.GameHistoryItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.math.absoluteValue
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ChartGameHistoryViewModel @Inject constructor(
+    subscribeChartGameHistoryUseCase: SubscribeChartGameHistoryUseCase
+) : ViewModel() {
+    val pagedChartGameFlow =
+        subscribeChartGameHistoryUseCase()
+            .map { pagingData ->
+                pagingData.map { chartGame ->
+                    val formatter =
+                        DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).localizedBy(
+                            Locale.getDefault()
+                        )
+
+                    GameHistoryItem(
+                        id = chartGame.id,
+                        ticker = chartGame.chart.tickerSymbol,
+                        totalTurn = chartGame.totalTurn,
+                        tickUnit = chartGame.chart.tickUnit,
+                        totalProfit = if (chartGame.accumulatedTotalProfit.value > 0.0) {
+                            "+"
+                        } else {
+                            "-"
+                        } + "%.2f".format(chartGame.accumulatedTotalProfit.value.absoluteValue),
+                        isTotalProfitPositive = chartGame.accumulatedTotalProfit.value > 0.0,
+                        time = "${chartGame.chart.startDateTime?.format(formatter) ?: ""} " +
+                            "-" +
+                            " ${chartGame.chart.endDateTime?.format(formatter) ?: ""}"
+                    )
+                }
+            }
+            .cachedIn(viewModelScope)
+
+    private val _screenEvent = MutableSharedFlow<ChartGameHistoryScreenEvent>()
+    val screenEvent: SharedFlow<ChartGameHistoryScreenEvent> = _screenEvent.asSharedFlow()
+
+    fun handleUserAction(userAction: ChartGameHistoryUserAction) =
+        viewModelScope.launch {
+            when (userAction) {
+                is ChartGameHistoryUserAction.ClickChartGameHistory -> {
+                    _screenEvent.emit(
+                        ChartGameHistoryScreenEvent.NavigateToTradeHistory(
+                            chartGameId = userAction.chartGameId
+                        )
+                    )
+                }
+
+                is ChartGameHistoryUserAction.ClickBack -> {
+                    _screenEvent.emit(ChartGameHistoryScreenEvent.NavigateToBack)
+                }
+            }
+        }
+}

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryViewModel.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryViewModel.kt
@@ -9,11 +9,7 @@ import com.yessorae.presentation.ui.screen.chartgamehistory.model.ChartGameHisto
 import com.yessorae.presentation.ui.screen.chartgamehistory.model.ChartGameHistoryUserAction
 import com.yessorae.presentation.ui.screen.chartgamehistory.model.GameHistoryItem
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
-import java.util.Locale
 import javax.inject.Inject
-import kotlin.math.absoluteValue
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -28,25 +24,16 @@ class ChartGameHistoryViewModel @Inject constructor(
         subscribeChartGameHistoryUseCase()
             .map { pagingData ->
                 pagingData.map { chartGame ->
-                    val formatter =
-                        DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).localizedBy(
-                            Locale.getDefault()
-                        )
 
                     GameHistoryItem(
                         id = chartGame.id,
                         ticker = chartGame.chart.tickerSymbol,
                         totalTurn = chartGame.totalTurn,
                         tickUnit = chartGame.chart.tickUnit,
-                        totalProfit = if (chartGame.accumulatedTotalProfit.value > 0.0) {
-                            "+"
-                        } else {
-                            "-"
-                        } + "%.2f".format(chartGame.accumulatedTotalProfit.value.absoluteValue),
+                        totalProfit = chartGame.accumulatedTotalProfit,
                         isTotalProfitPositive = chartGame.accumulatedTotalProfit.value > 0.0,
-                        time = "${chartGame.chart.startDateTime?.format(formatter) ?: ""} " +
-                            "-" +
-                            " ${chartGame.chart.endDateTime?.format(formatter) ?: ""}"
+                        startDate = chartGame.chart.startDateTime,
+                        endDate = chartGame.chart.endDateTime
                     )
                 }
             }

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/component/ChartGameHistoryListItem.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/component/ChartGameHistoryListItem.kt
@@ -1,0 +1,96 @@
+package com.yessorae.presentation.ui.screen.chartgamehistory.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.yessorae.domain.entity.tick.TickUnit
+import com.yessorae.presentation.ui.designsystem.theme.Dimen
+import com.yessorae.presentation.ui.designsystem.theme.StockDownColor
+import com.yessorae.presentation.ui.designsystem.theme.StockUpColor
+import com.yessorae.presentation.ui.designsystem.util.ChartTrainerIcons
+import com.yessorae.presentation.ui.designsystem.util.DevicePreviews
+import com.yessorae.presentation.ui.screen.chartgamehistory.model.GameHistoryItem
+
+class ChartGameHistoryListItem
+
+@Composable
+fun ChartGameHistoryListItem(
+    item: GameHistoryItem,
+    onClick: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(
+                vertical = 8.dp,
+                horizontal = Dimen.defaultLayoutSidePadding
+            )
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = item.ticker,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Text(
+                text = item.time,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = item.totalProfit,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                color = if (item.isTotalProfitPositive) {
+                    StockUpColor
+                } else {
+                    StockDownColor
+                }
+            )
+
+            Icon(
+                imageVector = ChartTrainerIcons.NavigateArrow,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.surfaceContainerHigh
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@Composable
+fun PreviewChartGameHistoryListItem() {
+    val item = GameHistoryItem(
+        id = 1L,
+        ticker = "AAPL",
+        totalTurn = 10,
+        tickUnit = TickUnit.DAY,
+        totalProfit = "+10%",
+        isTotalProfitPositive = true,
+        time = "01/01/2022 - 01/02/2022"
+    )
+    ChartGameHistoryListItem(item = item, onClick = {})
+}

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/component/ChartGameHistoryListItem.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/component/ChartGameHistoryListItem.kt
@@ -15,12 +15,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.yessorae.domain.entity.tick.TickUnit
+import com.yessorae.domain.entity.value.Money
 import com.yessorae.presentation.ui.designsystem.theme.Dimen
 import com.yessorae.presentation.ui.designsystem.theme.StockDownColor
 import com.yessorae.presentation.ui.designsystem.theme.StockUpColor
 import com.yessorae.presentation.ui.designsystem.util.ChartTrainerIcons
 import com.yessorae.presentation.ui.designsystem.util.DevicePreviews
+import com.yessorae.presentation.ui.designsystem.util.asDisplayTotalProfit
+import com.yessorae.presentation.ui.designsystem.util.getDisplayDateRangeText
 import com.yessorae.presentation.ui.screen.chartgamehistory.model.GameHistoryItem
+import java.time.LocalDateTime
 
 class ChartGameHistoryListItem
 
@@ -50,7 +54,7 @@ fun ChartGameHistoryListItem(
             )
 
             Text(
-                text = item.time,
+                text = getDisplayDateRangeText(item.startDate, item.endDate),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.surfaceContainerHigh
             )
@@ -61,7 +65,7 @@ fun ChartGameHistoryListItem(
             horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Text(
-                text = item.totalProfit,
+                text = item.totalProfit.asDisplayTotalProfit(),
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Bold,
                 color = if (item.isTotalProfitPositive) {
@@ -88,9 +92,10 @@ fun PreviewChartGameHistoryListItem() {
         ticker = "AAPL",
         totalTurn = 10,
         tickUnit = TickUnit.DAY,
-        totalProfit = "+10%",
+        totalProfit = Money(10.0),
         isTotalProfitPositive = true,
-        time = "01/01/2022 - 01/02/2022"
+        startDate = LocalDateTime.of(2024, 1, 1, 0, 0),
+        endDate = LocalDateTime.of(2026, 1, 1, 0, 0)
     )
     ChartGameHistoryListItem(item = item, onClick = {})
 }

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/model/ChartGameHistoryScreenEvent.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/model/ChartGameHistoryScreenEvent.kt
@@ -1,0 +1,9 @@
+package com.yessorae.presentation.ui.screen.chartgamehistory.model
+
+sealed interface ChartGameHistoryScreenEvent {
+    data class NavigateToTradeHistory(
+        val chartGameId: Long
+    ) : ChartGameHistoryScreenEvent
+
+    object NavigateToBack : ChartGameHistoryScreenEvent
+}

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/model/ChartGameHistoryUserAction.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/model/ChartGameHistoryUserAction.kt
@@ -1,0 +1,9 @@
+package com.yessorae.presentation.ui.screen.chartgamehistory.model
+
+sealed interface ChartGameHistoryUserAction {
+    data class ClickChartGameHistory(
+        val chartGameId: Long
+    ) : ChartGameHistoryUserAction
+
+    object ClickBack : ChartGameHistoryUserAction
+}

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/model/GameHistoryItem.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/model/GameHistoryItem.kt
@@ -1,0 +1,13 @@
+package com.yessorae.presentation.ui.screen.chartgamehistory.model
+
+import com.yessorae.domain.entity.tick.TickUnit
+
+data class GameHistoryItem(
+    val id: Long,
+    val ticker: String,
+    val totalTurn: Int,
+    val tickUnit: TickUnit,
+    val totalProfit: String,
+    val isTotalProfitPositive: Boolean,
+    val time: String = ""
+)

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/model/GameHistoryItem.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/model/GameHistoryItem.kt
@@ -1,13 +1,16 @@
 package com.yessorae.presentation.ui.screen.chartgamehistory.model
 
 import com.yessorae.domain.entity.tick.TickUnit
+import com.yessorae.domain.entity.value.Money
+import java.time.LocalDateTime
 
 data class GameHistoryItem(
     val id: Long,
     val ticker: String,
     val totalTurn: Int,
     val tickUnit: TickUnit,
-    val totalProfit: String,
+    val totalProfit: Money,
     val isTotalProfitPositive: Boolean,
-    val time: String = ""
+    val startDate: LocalDateTime?,
+    val endDate: LocalDateTime?
 )

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/HomeNavigation.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/HomeNavigation.kt
@@ -4,12 +4,16 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 
 const val HOME_ROUTE = "home_route"
-fun NavGraphBuilder.homeScreen(navigateToChartGame: (Long?) -> Unit) {
+fun NavGraphBuilder.homeScreen(
+    navigateToChartGame: (Long?) -> Unit,
+    navigateToChartGameHistory: () -> Unit
+) {
     composable(
         route = HOME_ROUTE
     ) {
         HomeScreenRoute(
-            navigateToChartGame = navigateToChartGame
+            navigateToChartGame = navigateToChartGame,
+            navigateToChartGameHistory = navigateToChartGameHistory
         )
     }
 }

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/HomeScreen.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.yessorae.presentation.R
 import com.yessorae.presentation.ui.designsystem.component.ChartTrainerLoadingProgressBar
+import com.yessorae.presentation.ui.designsystem.component.DefaultIconButton
 import com.yessorae.presentation.ui.designsystem.theme.Dimen
+import com.yessorae.presentation.ui.designsystem.util.ChartTrainerIcons
 import com.yessorae.presentation.ui.designsystem.util.showToast
 import com.yessorae.presentation.ui.screen.home.component.CommissionRateSettingDialog
 import com.yessorae.presentation.ui.screen.home.component.HomeBottomButton
@@ -40,14 +42,16 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun HomeScreenRoute(
     viewModel: HomeViewModel = hiltViewModel(),
-    navigateToChartGame: (Long?) -> Unit
+    navigateToChartGame: (Long?) -> Unit,
+    navigateToChartGameHistory: () -> Unit
 ) {
     val screenState by viewModel.screenState.collectAsState()
     HomeScreen(screenState = screenState)
 
     HomeScreenEventHandler(
         screenEvent = viewModel.screenEvent,
-        navigateToChartGame = navigateToChartGame
+        navigateToChartGame = navigateToChartGame,
+        navigateToChartGameHistory = navigateToChartGameHistory
     )
 }
 
@@ -59,6 +63,14 @@ fun HomeScreen(screenState: HomeState) {
             TopAppBar(
                 title = {
                     Text(text = stringResource(id = R.string.home_title))
+                },
+                actions = {
+                    DefaultIconButton(
+                        imageVector = ChartTrainerIcons.ChartGameList,
+                        onClick = {
+                            screenState.onUserAction(HomeScreenUserAction.ClickChartGameHistory)
+                        }
+                    )
                 }
             )
         },
@@ -155,7 +167,8 @@ fun HomeScreen(screenState: HomeState) {
 @Composable
 fun HomeScreenEventHandler(
     screenEvent: SharedFlow<HomeScreenEvent>,
-    navigateToChartGame: (Long?) -> Unit
+    navigateToChartGame: (Long?) -> Unit,
+    navigateToChartGameHistory: () -> Unit
 ) {
     val context = LocalContext.current
     LaunchedEffect(key1 = Unit) {
@@ -171,6 +184,10 @@ fun HomeScreenEventHandler(
 
                 is HomeScreenEvent.TotalTurnSettingError -> {
                     context.showToast(id = R.string.home_error_toast_turn_setting)
+                }
+
+                is HomeScreenEvent.NavigateToChartGameHistoryScreen -> {
+                    navigateToChartGameHistory()
                 }
             }
         }

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/HomeViewModel.kt
@@ -214,6 +214,10 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }
+
+            is HomeScreenUserAction.ClickChartGameHistory -> {
+                _screenEvent.emit(HomeScreenEvent.NavigateToChartGameHistoryScreen)
+            }
         }
     }
 

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/model/HomeScreenEvent.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/model/HomeScreenEvent.kt
@@ -5,6 +5,8 @@ sealed interface HomeScreenEvent {
         val chartGameId: Long?
     ) : HomeScreenEvent
 
+    object NavigateToChartGameHistoryScreen : HomeScreenEvent
+
     object CommissionRateSettingError : HomeScreenEvent
 
     object TotalTurnSettingError : HomeScreenEvent

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/model/HomeScreenUserAction.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/home/model/HomeScreenUserAction.kt
@@ -7,4 +7,5 @@ sealed interface HomeScreenUserAction {
     object ClickCommissionRate : HomeScreenUserAction
     object ClickTotalTurn : HomeScreenUserAction
     object ClickTickUnit : HomeScreenUserAction
+    object ClickChartGameHistory : HomeScreenUserAction
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="trade_history_guide_commission">수수료</string>
     <string name="trade_history_guide_profit">실현손익</string>
 
+    <!-- chart_game_history_item -->
+    <string name="chart_game_history_title">차트게임 내역</string>
 
     <!-- chart_game -->
     <string name="chart_game_toast_trade_buy">%d 주를 매수했습니다.</string>


### PR DESCRIPTION
close #7 

# Overview
- 게임 내역을 리스트로 확인하는 화면을 추가합니다. 
- 여러날에 걸쳐 게임하면 수가 많아질 수 있으니 페이징 처리하였습니다. * #51 TradeHistory같은 경우는 하나의 게임에 진행한 매매개수로  페이징 하지 않고 그대로 가져옵니다. 
  - 그런데 악성유저를 고려한다면 TradeHistory 도 페이징할지는 고민중입니다. 현재 DB구조를 바꿔야하기도 하구요.
