### PR TITLE
[CT-55] Chart(Tick포함), Trade 모델을 ChartGame 모델로부터 분리

### DIFF
--- a/data/src/main/java/com/yessorae/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/yessorae/data/di/RepositoryModule.kt
@@ -2,9 +2,11 @@ package com.yessorae.data.di
 
 import com.yessorae.data.repository.ChartGameRepositoryImpl
 import com.yessorae.data.repository.ChartRepositoryImpl
+import com.yessorae.data.repository.TradeRepositoryImpl
 import com.yessorae.data.repository.UserRepositoryImpl
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.ChartRepository
+import com.yessorae.domain.repository.TradeRepository
 import com.yessorae.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
@@ -24,6 +26,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindsChartRepository(chartRepository: ChartRepositoryImpl): ChartRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsTradeRepository(tradeRepository: TradeRepositoryImpl): TradeRepository
 
     @Binds
     @Singleton

--- a/data/src/main/java/com/yessorae/data/repository/ChartGameRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/ChartGameRepositoryImpl.kt
@@ -12,13 +12,13 @@ import com.yessorae.data.source.local.database.model.asEntity
 import com.yessorae.data.source.local.preference.ChartTrainerPreferencesDataSource
 import com.yessorae.domain.entity.ChartGame
 import com.yessorae.domain.repository.ChartGameRepository
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 class ChartGameRepositoryImpl @Inject constructor(
     private val localDataSource: ChartTrainerLocalDBDataSource,

--- a/data/src/main/java/com/yessorae/data/repository/ChartGameRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/ChartGameRepositoryImpl.kt
@@ -54,10 +54,6 @@ class ChartGameRepositoryImpl @Inject constructor(
     override suspend fun fetchChartGame(gameId: Long): ChartGame =
         localDataSource.getChartGame(id = gameId).asDomainModel()
 
-    override suspend fun fetchChartId(gameId: Long): Long {
-        return localDataSource.getChartGame(id = gameId).chartId
-    }
-
     override suspend fun updateChartGame(chartGame: ChartGame): Unit =
         withContext(dispatcher) {
             launch {

--- a/data/src/main/java/com/yessorae/data/repository/ChartGameRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/ChartGameRepositoryImpl.kt
@@ -7,32 +7,24 @@ import androidx.paging.map
 import com.yessorae.data.di.ChartTrainerDispatcher
 import com.yessorae.data.di.Dispatcher
 import com.yessorae.data.source.ChartTrainerLocalDBDataSource
-import com.yessorae.data.source.local.database.model.TickEntity
-import com.yessorae.data.source.local.database.model.TradeEntity
 import com.yessorae.data.source.local.database.model.asDomainModel
 import com.yessorae.data.source.local.database.model.asEntity
 import com.yessorae.data.source.local.preference.ChartTrainerPreferencesDataSource
-import com.yessorae.data.source.network.polygon.util.DatabaseTransactionHelper
 import com.yessorae.domain.entity.ChartGame
-import com.yessorae.domain.entity.trade.Trade
 import com.yessorae.domain.repository.ChartGameRepository
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 class ChartGameRepositoryImpl @Inject constructor(
     private val localDataSource: ChartTrainerLocalDBDataSource,
     private val chartGamePreferencesDataSource: ChartTrainerPreferencesDataSource,
     @Dispatcher(ChartTrainerDispatcher.IO)
-    private val dispatcher: CoroutineDispatcher,
-    private val transactionHelper: DatabaseTransactionHelper
+    private val dispatcher: CoroutineDispatcher
 ) : ChartGameRepository {
     override suspend fun createNewChartGame(chartGame: ChartGame): Long =
         withContext(dispatcher) {
@@ -40,22 +32,11 @@ class ChartGameRepositoryImpl @Inject constructor(
         }
 
     override fun fetchChartGameFlow(gameId: Long): Flow<ChartGame> {
-        return combine(
-            localDataSource.getChartGameAsFlow(id = gameId),
-            localDataSource.getTradesAsFlow(gameId = gameId),
-            ::Pair
-        )
-            .distinctUntilChanged()
-            .map { (chartGame, newTrades) ->
-                val chart = localDataSource.getChart(id = chartGame.chartId)
-                val ticks =
-                    localDataSource.getTicks(chartId = chart.id).map(TickEntity::asDomainModel)
-                chartGame.asDomainModel(
-                    chart = chart.asDomainModel(ticks = ticks),
-                    trades = newTrades.map(transform = TradeEntity::asDomainModel)
-                )
-            }
+        return localDataSource.getChartGameAsFlow(id = gameId)
             .flowOn(dispatcher)
+            .map { chartGameEntity ->
+                chartGameEntity.asDomainModel()
+            }
     }
 
     override fun fetchPagedChartGameFlow(pagingConfig: PagingConfig): Flow<PagingData<ChartGame>> {
@@ -66,41 +47,21 @@ class ChartGameRepositoryImpl @Inject constructor(
         }
             .flow
             .map { pagingData ->
-                pagingData.map { chartGameEntity -> makeChartGame(gameId = chartGameEntity.id) }
+                pagingData.map { chartGameEntity -> chartGameEntity.asDomainModel() }
             }
     }
 
-    override suspend fun fetchChartGame(gameId: Long): ChartGame = makeChartGame(gameId = gameId)
+    override suspend fun fetchChartGame(gameId: Long): ChartGame =
+        localDataSource.getChartGame(id = gameId).asDomainModel()
 
-    private suspend fun makeChartGame(gameId: Long): ChartGame =
+    override suspend fun fetchChartId(gameId: Long): Long {
+        return localDataSource.getChartGame(id = gameId).chartId
+    }
+
+    override suspend fun updateChartGame(chartGame: ChartGame): Unit =
         withContext(dispatcher) {
-            val chartGameJob = async { localDataSource.getChartGame(id = gameId) }
-            val tradesJob = async { localDataSource.getTrades(gameId = gameId) }
-
-            val chartGame = chartGameJob.await()
-            val chart = localDataSource.getChart(id = chartGame.chartId)
-            val ticks = localDataSource.getTicks(chartId = chart.id).map(TickEntity::asDomainModel)
-
-            chartGame.asDomainModel(
-                chart = chart.asDomainModel(ticks = ticks),
-                trades = tradesJob.await().map(transform = TradeEntity::asDomainModel)
-            )
-        }
-
-    override suspend fun updateChartGame(chartGame: ChartGame) =
-        withContext(dispatcher) {
-            transactionHelper.runTransaction {
-                launch {
-                    localDataSource.insertOrReplaceAllTrades(
-                        entities = chartGame.trades.map(Trade::asEntity)
-                    )
-                }
-                launch {
-                    localDataSource.updateChart(entity = chartGame.chart.asEntity())
-                }
-                launch {
-                    localDataSource.updateChartGame(chartGame.asEntity())
-                }
+            launch {
+                localDataSource.updateChartGame(chartGame.asEntity())
             }
         }
 

--- a/data/src/main/java/com/yessorae/data/repository/ChartRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/ChartRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.yessorae.data.di.ChartTrainerDispatcher
 import com.yessorae.data.di.Dispatcher
 import com.yessorae.data.source.ChartNetworkDataSource
 import com.yessorae.data.source.ChartTrainerLocalDBDataSource
+import com.yessorae.data.source.local.database.model.asDomainModel
 import com.yessorae.data.source.local.database.model.asEntity
 import com.yessorae.data.source.local.preference.ChartTrainerPreferencesDataSource
 import com.yessorae.data.source.network.polygon.model.chart.asDomainModel
@@ -63,6 +64,14 @@ class ChartRepositoryImpl @Inject constructor(
         val chartId = localDBDataSource.insertChart(chart.asEntity())
         localDBDataSource.insertTicks(chart.ticks.map { it.asEntity(chartId = chartId) })
         return chart.copy(id = chartId)
+    }
+
+    override suspend fun fetchChart(gameId: Long): Chart {
+        val chartId = localDBDataSource.getChartId(gameId = gameId)
+        val chartEntity = localDBDataSource.getChart(id = chartId)
+        val ticks = localDBDataSource.getTicks(chartId = chartId)
+
+        return chartEntity.asDomainModel(ticks.map { it.asDomainModel() })
     }
 
     companion object {

--- a/data/src/main/java/com/yessorae/data/repository/ChartRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/ChartRepositoryImpl.kt
@@ -66,13 +66,8 @@ class ChartRepositoryImpl @Inject constructor(
         return chart.copy(id = chartId)
     }
 
-    override suspend fun fetchChart(gameId: Long): Chart {
-        val chartId = localDBDataSource.getChartId(gameId = gameId)
-        val chartEntity = localDBDataSource.getChart(id = chartId)
-        val ticks = localDBDataSource.getTicks(chartId = chartId)
-
-        return chartEntity.asDomainModel(ticks.map { it.asDomainModel() })
-    }
+    override suspend fun fetchChart(gameId: Long): Chart =
+        localDBDataSource.getChartWithTicks(gameId = gameId).asDomainModel()
 
     companion object {
         private const val RETRY_COUNT = 3

--- a/data/src/main/java/com/yessorae/data/repository/TradeRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/TradeRepositoryImpl.kt
@@ -6,10 +6,8 @@ import com.yessorae.data.source.local.database.model.asDomainModel
 import com.yessorae.data.source.local.database.model.asEntity
 import com.yessorae.domain.entity.trade.Trade
 import com.yessorae.domain.repository.TradeRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
-
+import kotlinx.coroutines.flow.map
 
 class TradeRepositoryImpl @Inject constructor(
     private val localDBDataSource: ChartTrainerLocalDBDataSource

--- a/data/src/main/java/com/yessorae/data/repository/TradeRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/TradeRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.yessorae.data.repository
+
+import com.yessorae.data.source.ChartTrainerLocalDBDataSource
+import com.yessorae.data.source.local.database.model.TradeEntity
+import com.yessorae.data.source.local.database.model.asDomainModel
+import com.yessorae.data.source.local.database.model.asEntity
+import com.yessorae.domain.entity.trade.Trade
+import com.yessorae.domain.repository.TradeRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+
+class TradeRepositoryImpl @Inject constructor(
+    private val localDBDataSource: ChartTrainerLocalDBDataSource
+) : TradeRepository {
+    override suspend fun fetchTrades(gameId: Long): List<Trade> =
+        localDBDataSource.getTrades(gameId = gameId).map(TradeEntity::asDomainModel)
+
+    override suspend fun createTrade(trade: Trade): Long =
+        localDBDataSource.insertTrade(entity = trade.asEntity())
+
+    override suspend fun updateTrades(trades: List<Trade>) =
+        localDBDataSource.insertOrReplaceAllTrades(entities = trades.map(Trade::asEntity))
+}

--- a/data/src/main/java/com/yessorae/data/repository/TradeRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/TradeRepositoryImpl.kt
@@ -19,7 +19,4 @@ class TradeRepositoryImpl @Inject constructor(
 
     override suspend fun createTrade(trade: Trade): Long =
         localDBDataSource.insertTrade(entity = trade.asEntity())
-
-    override suspend fun updateTrades(trades: List<Trade>) =
-        localDBDataSource.insertOrReplaceAllTrades(entities = trades.map(Trade::asEntity))
 }

--- a/data/src/main/java/com/yessorae/data/repository/TradeRepositoryImpl.kt
+++ b/data/src/main/java/com/yessorae/data/repository/TradeRepositoryImpl.kt
@@ -7,7 +7,6 @@ import com.yessorae.data.source.local.database.model.asEntity
 import com.yessorae.domain.entity.trade.Trade
 import com.yessorae.domain.repository.TradeRepository
 import javax.inject.Inject
-import kotlinx.coroutines.flow.map
 
 class TradeRepositoryImpl @Inject constructor(
     private val localDBDataSource: ChartTrainerLocalDBDataSource

--- a/data/src/main/java/com/yessorae/data/source/ChartTrainerLocalDBDataSource.kt
+++ b/data/src/main/java/com/yessorae/data/source/ChartTrainerLocalDBDataSource.kt
@@ -3,6 +3,7 @@ package com.yessorae.data.source
 import androidx.paging.PagingSource
 import com.yessorae.data.source.local.database.model.ChartEntity
 import com.yessorae.data.source.local.database.model.ChartGameEntity
+import com.yessorae.data.source.local.database.model.ChartWithTicksEntity
 import com.yessorae.data.source.local.database.model.TickEntity
 import com.yessorae.data.source.local.database.model.TradeEntity
 import kotlinx.coroutines.flow.Flow
@@ -12,10 +13,8 @@ interface ChartTrainerLocalDBDataSource {
     fun getChartGameAsFlow(id: Long): Flow<ChartGameEntity>
     fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity>
     suspend fun getChartGame(id: Long): ChartGameEntity
-    suspend fun getChartId(gameId: Long): Long
     suspend fun getTrades(gameId: Long): List<TradeEntity>
-    suspend fun getChart(id: Long): ChartEntity
-    suspend fun getTicks(chartId: Long): List<TickEntity>
+    suspend fun getChartWithTicks(gameId: Long): ChartWithTicksEntity
     suspend fun insertCharGame(entity: ChartGameEntity): Long
     suspend fun insertChart(entity: ChartEntity): Long
     suspend fun insertTrade(entity: TradeEntity): Long

--- a/data/src/main/java/com/yessorae/data/source/ChartTrainerLocalDBDataSource.kt
+++ b/data/src/main/java/com/yessorae/data/source/ChartTrainerLocalDBDataSource.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.Flow
 interface ChartTrainerLocalDBDataSource {
     fun getChartGameAsFlow(id: Long): Flow<ChartGameEntity>
     fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity>
-    fun getTradesAsFlow(gameId: Long): Flow<List<TradeEntity>>
     suspend fun getChartGame(id: Long): ChartGameEntity
     suspend fun getChartId(gameId: Long): Long
     suspend fun getTrades(gameId: Long): List<TradeEntity>
@@ -22,6 +21,4 @@ interface ChartTrainerLocalDBDataSource {
     suspend fun insertTrade(entity: TradeEntity): Long
     suspend fun insertTicks(entities: List<TickEntity>)
     suspend fun updateChartGame(entity: ChartGameEntity)
-    suspend fun insertOrReplaceAllTrades(entities: List<TradeEntity>)
-    suspend fun updateChart(entity: ChartEntity)
 }

--- a/data/src/main/java/com/yessorae/data/source/ChartTrainerLocalDBDataSource.kt
+++ b/data/src/main/java/com/yessorae/data/source/ChartTrainerLocalDBDataSource.kt
@@ -13,11 +13,13 @@ interface ChartTrainerLocalDBDataSource {
     fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity>
     fun getTradesAsFlow(gameId: Long): Flow<List<TradeEntity>>
     suspend fun getChartGame(id: Long): ChartGameEntity
+    suspend fun getChartId(gameId: Long): Long
     suspend fun getTrades(gameId: Long): List<TradeEntity>
     suspend fun getChart(id: Long): ChartEntity
     suspend fun getTicks(chartId: Long): List<TickEntity>
     suspend fun insertCharGame(entity: ChartGameEntity): Long
     suspend fun insertChart(entity: ChartEntity): Long
+    suspend fun insertTrade(entity: TradeEntity): Long
     suspend fun insertTicks(entities: List<TickEntity>)
     suspend fun updateChartGame(entity: ChartGameEntity)
     suspend fun insertOrReplaceAllTrades(entities: List<TradeEntity>)

--- a/data/src/main/java/com/yessorae/data/source/local/database/ChartTrainerLocalDBDataSourceImpl.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/ChartTrainerLocalDBDataSourceImpl.kt
@@ -25,9 +25,6 @@ class ChartTrainerLocalDBDataSourceImpl @Inject constructor(
     override fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity> =
         chartGameDao.getChartGamePagingSource()
 
-    override fun getTradesAsFlow(gameId: Long): Flow<List<TradeEntity>> =
-        tradeDao.getTradesAsFlow(gameId = gameId)
-
     override suspend fun getChartGame(id: Long): ChartGameEntity =
         chartGameDao.getChartGame(id = id)
 
@@ -57,11 +54,4 @@ class ChartTrainerLocalDBDataSourceImpl @Inject constructor(
         chartGameDao.update(
             entity = entity
         )
-
-    override suspend fun insertOrReplaceAllTrades(entities: List<TradeEntity>) =
-        tradeDao.insertOrReplaceAll(
-            entities = entities
-        )
-
-    override suspend fun updateChart(entity: ChartEntity) = chartDao.update(entity = entity)
 }

--- a/data/src/main/java/com/yessorae/data/source/local/database/ChartTrainerLocalDBDataSourceImpl.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/ChartTrainerLocalDBDataSourceImpl.kt
@@ -31,6 +31,8 @@ class ChartTrainerLocalDBDataSourceImpl @Inject constructor(
     override suspend fun getChartGame(id: Long): ChartGameEntity =
         chartGameDao.getChartGame(id = id)
 
+    override suspend fun getChartId(gameId: Long): Long = chartGameDao.getChartId(gameId = gameId)
+
     override suspend fun getTrades(gameId: Long): List<TradeEntity> =
         tradeDao.getTrades(gameId = gameId)
 
@@ -45,6 +47,8 @@ class ChartTrainerLocalDBDataSourceImpl @Inject constructor(
         )
 
     override suspend fun insertChart(entity: ChartEntity): Long = chartDao.insert(entity = entity)
+
+    override suspend fun insertTrade(entity: TradeEntity): Long = tradeDao.insert(entity = entity)
 
     override suspend fun insertTicks(entities: List<TickEntity>) =
         tickDao.insertAll(entities = entities)

--- a/data/src/main/java/com/yessorae/data/source/local/database/ChartTrainerLocalDBDataSourceImpl.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/ChartTrainerLocalDBDataSourceImpl.kt
@@ -8,6 +8,7 @@ import com.yessorae.data.source.local.database.dao.TickDao
 import com.yessorae.data.source.local.database.dao.TradeDao
 import com.yessorae.data.source.local.database.model.ChartEntity
 import com.yessorae.data.source.local.database.model.ChartGameEntity
+import com.yessorae.data.source.local.database.model.ChartWithTicksEntity
 import com.yessorae.data.source.local.database.model.TickEntity
 import com.yessorae.data.source.local.database.model.TradeEntity
 import javax.inject.Inject
@@ -28,15 +29,13 @@ class ChartTrainerLocalDBDataSourceImpl @Inject constructor(
     override suspend fun getChartGame(id: Long): ChartGameEntity =
         chartGameDao.getChartGame(id = id)
 
-    override suspend fun getChartId(gameId: Long): Long = chartGameDao.getChartId(gameId = gameId)
-
     override suspend fun getTrades(gameId: Long): List<TradeEntity> =
         tradeDao.getTrades(gameId = gameId)
 
-    override suspend fun getChart(id: Long): ChartEntity = chartDao.getChart(id = id)
-
-    override suspend fun getTicks(chartId: Long): List<TickEntity> =
-        tickDao.getTicks(chartId = chartId)
+    override suspend fun getChartWithTicks(gameId: Long): ChartWithTicksEntity {
+        val chartId = chartGameDao.getChartId(gameId = gameId)
+        return chartDao.getChartWithTicks(id = chartId)
+    }
 
     override suspend fun insertCharGame(entity: ChartGameEntity): Long =
         chartGameDao.insert(

--- a/data/src/main/java/com/yessorae/data/source/local/database/dao/ChartDao.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/dao/ChartDao.kt
@@ -2,7 +2,9 @@ package com.yessorae.data.source.local.database.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
 import com.yessorae.data.source.local.database.model.ChartEntity
+import com.yessorae.data.source.local.database.model.ChartWithTicksEntity
 
 @Dao
 interface ChartDao : BaseDao<ChartEntity> {
@@ -12,4 +14,12 @@ interface ChartDao : BaseDao<ChartEntity> {
         """
     )
     suspend fun getChart(id: Long): ChartEntity
+
+    @Transaction
+    @Query(
+        """
+            SELECT * FROM ${ChartEntity.NAME} WHERE id = :id
+        """
+    )
+    suspend fun getChartWithTicks(id: Long): ChartWithTicksEntity
 }

--- a/data/src/main/java/com/yessorae/data/source/local/database/dao/ChartGameDao.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/dao/ChartGameDao.kt
@@ -28,4 +28,11 @@ interface ChartGameDao : BaseDao<ChartGameEntity> {
         """
     )
     fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity>
+
+    @Query(
+        """
+            SELECT ${ChartGameEntity.COL_CHART_ID} from ${ChartGameEntity.NAME} WHERE id = (:gameId) 
+        """
+    )
+    fun getChartId(gameId: Long): Long
 }

--- a/data/src/main/java/com/yessorae/data/source/local/database/dao/ChartGameDao.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/dao/ChartGameDao.kt
@@ -24,7 +24,7 @@ interface ChartGameDao : BaseDao<ChartGameEntity> {
 
     @Query(
         """
-            SELECT * from ${ChartGameEntity.NAME}
+            SELECT * from ${ChartGameEntity.NAME} WHERE ${ChartGameEntity.COL_IS_QUIT} = 0
         """
     )
     fun getChartGamePagingSource(): PagingSource<Int, ChartGameEntity>

--- a/data/src/main/java/com/yessorae/data/source/local/database/dao/TradeDao.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/dao/TradeDao.kt
@@ -12,12 +12,5 @@ interface TradeDao : BaseDao<TradeEntity> {
             SELECT * FROM ${TradeEntity.NAME} WHERE ${TradeEntity.COL_GAME_ID} = :gameId
         """
     )
-    fun getTradesAsFlow(gameId: Long): Flow<List<TradeEntity>>
-
-    @Query(
-        """
-            SELECT * FROM ${TradeEntity.NAME} WHERE ${TradeEntity.COL_GAME_ID} = :gameId
-        """
-    )
     suspend fun getTrades(gameId: Long): List<TradeEntity>
 }

--- a/data/src/main/java/com/yessorae/data/source/local/database/dao/TradeDao.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/dao/TradeDao.kt
@@ -3,7 +3,6 @@ package com.yessorae.data.source.local.database.dao
 import androidx.room.Dao
 import androidx.room.Query
 import com.yessorae.data.source.local.database.model.TradeEntity
-import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface TradeDao : BaseDao<TradeEntity> {

--- a/data/src/main/java/com/yessorae/data/source/local/database/model/ChartEntity.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/model/ChartEntity.kt
@@ -4,13 +4,13 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.yessorae.domain.entity.Chart
-import com.yessorae.domain.entity.tick.Tick
 import com.yessorae.domain.entity.tick.TickUnit
 import java.time.LocalDateTime
 
 @Entity(tableName = ChartEntity.NAME)
 data class ChartEntity(
     @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = COL_ID)
     val id: Long,
     @ColumnInfo(name = COL_TICKER_SYMBOL)
     val tickerSymbol: String,
@@ -23,6 +23,7 @@ data class ChartEntity(
 ) {
     companion object {
         const val NAME = "chart_table"
+        const val COL_ID = "id"
         const val COL_TICKER_SYMBOL = "ticker_symbol"
         const val COL_START_DATE_TIME = "start_date_time"
         const val COL_END_DATE_TIME = "end_date_time"
@@ -36,15 +37,5 @@ fun Chart.asEntity() =
         tickerSymbol = tickerSymbol,
         startDateTime = startDateTime,
         endDateTime = endDateTime,
-        tickUnit = tickUnit
-    )
-
-fun ChartEntity.asDomainModel(ticks: List<Tick>) =
-    Chart(
-        id = id,
-        tickerSymbol = tickerSymbol,
-        startDateTime = startDateTime,
-        endDateTime = endDateTime,
-        ticks = ticks,
         tickUnit = tickUnit
     )

--- a/data/src/main/java/com/yessorae/data/source/local/database/model/ChartGameEntity.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/model/ChartGameEntity.kt
@@ -3,9 +3,7 @@ package com.yessorae.data.source.local.database.model
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.yessorae.domain.entity.Chart
 import com.yessorae.domain.entity.ChartGame
-import com.yessorae.domain.entity.trade.Trade
 import com.yessorae.domain.entity.value.Money
 
 @Entity(ChartGameEntity.NAME)
@@ -33,7 +31,7 @@ data class ChartGameEntity(
     @ColumnInfo(name = COL_AVERAGE_STOCK_PRICE)
     val averageStockPrice: Money,
     @ColumnInfo(name = COL_ACCUMULATED_TOTAL_PROFIT)
-    val accumulatedTotalProfit: Money,
+    val accumulatedTotalProfit: Money
 ) {
     companion object {
         const val NAME = "chart_game_table"
@@ -67,17 +65,18 @@ fun ChartGame.asEntity() =
         accumulatedTotalProfit = accumulatedTotalProfit
     )
 
-fun ChartGameEntity.asDomainModel() = ChartGame(
-    id = id,
-    chartId = chartId,
-    currentTurn = currentTurn,
-    totalTurn = totalTurn,
-    startBalance = startBalance,
-    currentBalance = currentBalance,
-    isQuit = isQuit,
-    closeStockPrice = closeStockPrice,
-    totalStockCount = totalStockCount,
-    totalStockPrice = totalStockPrice,
-    averageStockPrice = averageStockPrice,
-    accumulatedTotalProfit = accumulatedTotalProfit
-)
+fun ChartGameEntity.asDomainModel() =
+    ChartGame(
+        id = id,
+        chartId = chartId,
+        currentTurn = currentTurn,
+        totalTurn = totalTurn,
+        startBalance = startBalance,
+        currentBalance = currentBalance,
+        isQuit = isQuit,
+        closeStockPrice = closeStockPrice,
+        totalStockCount = totalStockCount,
+        totalStockPrice = totalStockPrice,
+        averageStockPrice = averageStockPrice,
+        accumulatedTotalProfit = accumulatedTotalProfit
+    )

--- a/data/src/main/java/com/yessorae/data/source/local/database/model/ChartGameEntity.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/model/ChartGameEntity.kt
@@ -23,7 +23,17 @@ data class ChartGameEntity(
     @ColumnInfo(name = COL_CURRENT_BALANCE)
     val currentBalance: Money,
     @ColumnInfo(name = COL_IS_QUIT)
-    val isQuit: Boolean
+    val isQuit: Boolean,
+    @ColumnInfo(name = COL_CLOSE_STOCK_PRICE)
+    val closeStockPrice: Money,
+    @ColumnInfo(name = COL_TOTAL_STOCK_COUNT)
+    val totalStockCount: Int,
+    @ColumnInfo(name = COL_TOTAL_STOCK_PRICE)
+    val totalStockPrice: Money,
+    @ColumnInfo(name = COL_AVERAGE_STOCK_PRICE)
+    val averageStockPrice: Money,
+    @ColumnInfo(name = COL_ACCUMULATED_TOTAL_PROFIT)
+    val accumulatedTotalProfit: Money,
 ) {
     companion object {
         const val NAME = "chart_game_table"
@@ -33,30 +43,41 @@ data class ChartGameEntity(
         const val COL_START_BALANCE = "start_balance"
         const val COL_CURRENT_BALANCE = "current_balance"
         const val COL_IS_QUIT = "is_quit"
+        const val COL_CLOSE_STOCK_PRICE = "close_stock_price"
+        const val COL_TOTAL_STOCK_COUNT = "total_stock_count"
+        const val COL_TOTAL_STOCK_PRICE = "total_stock_price"
+        const val COL_AVERAGE_STOCK_PRICE = "average_stock_price"
+        const val COL_ACCUMULATED_TOTAL_PROFIT = "accumulated_total_profit"
     }
 }
 
 fun ChartGame.asEntity() =
     ChartGameEntity(
         id = id,
-        chartId = chart.id,
+        chartId = chartId,
         currentTurn = currentTurn,
         totalTurn = totalTurn,
         startBalance = startBalance,
         currentBalance = currentBalance,
-        isQuit = isQuit
+        isQuit = isQuit,
+        closeStockPrice = closeStockPrice,
+        totalStockCount = totalStockCount,
+        totalStockPrice = totalStockPrice,
+        averageStockPrice = averageStockPrice,
+        accumulatedTotalProfit = accumulatedTotalProfit
     )
 
-fun ChartGameEntity.asDomainModel(
-    chart: Chart,
-    trades: List<Trade>
-) = ChartGame(
+fun ChartGameEntity.asDomainModel() = ChartGame(
     id = id,
-    chart = chart,
-    trades = trades,
+    chartId = chartId,
     currentTurn = currentTurn,
     totalTurn = totalTurn,
     startBalance = startBalance,
     currentBalance = currentBalance,
-    isQuit = isQuit
+    isQuit = isQuit,
+    closeStockPrice = closeStockPrice,
+    totalStockCount = totalStockCount,
+    totalStockPrice = totalStockPrice,
+    averageStockPrice = averageStockPrice,
+    accumulatedTotalProfit = accumulatedTotalProfit
 )

--- a/data/src/main/java/com/yessorae/data/source/local/database/model/ChartWithTicksEntity.kt
+++ b/data/src/main/java/com/yessorae/data/source/local/database/model/ChartWithTicksEntity.kt
@@ -1,0 +1,25 @@
+package com.yessorae.data.source.local.database.model
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.yessorae.domain.entity.Chart
+
+data class ChartWithTicksEntity(
+    @Embedded
+    val chart: ChartEntity,
+    @Relation(
+        parentColumn = ChartEntity.COL_ID,
+        entityColumn = TickEntity.COL_CHART_ID
+    )
+    val ticks: List<TickEntity>
+)
+
+fun ChartWithTicksEntity.asDomainModel() =
+    Chart(
+        id = chart.id,
+        tickerSymbol = chart.tickerSymbol,
+        startDateTime = chart.startDateTime,
+        endDateTime = chart.endDateTime,
+        tickUnit = chart.tickUnit,
+        ticks = ticks.map { it.asDomainModel() }
+    )

--- a/domain/src/main/java/com/yessorae/domain/entity/ChartGame.kt
+++ b/domain/src/main/java/com/yessorae/domain/entity/ChartGame.kt
@@ -18,7 +18,7 @@ data class ChartGame(
     // 현재 종가
     val closeStockPrice: Money,
     // 유저의 게임 강제 종료 여부
-    val isQuit: Boolean, // TODO::NOW 쿼리할 때 isQuit 가 true인 것을 제외하고 가져오도록 수정 필요
+    val isQuit: Boolean,
     // 현재 보유 주식 수량
     val totalStockCount: Int,
     // 현재 보유 주식 가격의 총합
@@ -26,7 +26,7 @@ data class ChartGame(
     // 현재 보유 주식 평단가
     val averageStockPrice: Money,
     // 누적 수익
-    val accumulatedTotalProfit: Money,
+    val accumulatedTotalProfit: Money
 ) {
 
     // 누적 수익률
@@ -80,9 +80,7 @@ data class ChartGame(
         )
     }
 
-    internal fun getChartChangeResult(
-        closeStockPrice: Money
-    ): ChartGame {
+    internal fun getChartChangeResult(closeStockPrice: Money): ChartGame {
         return copy(
             currentTurn = START_TURN,
             currentBalance = startBalance,
@@ -107,7 +105,7 @@ data class ChartGame(
             chartId: Long,
             totalTurn: Int,
             startBalance: Money,
-            closeStockPrice: Money,
+            closeStockPrice: Money
         ): ChartGame {
             return ChartGame(
                 chartId = chartId,

--- a/domain/src/main/java/com/yessorae/domain/entity/ChartGame.kt
+++ b/domain/src/main/java/com/yessorae/domain/entity/ChartGame.kt
@@ -1,15 +1,12 @@
 package com.yessorae.domain.entity
 
-import com.yessorae.domain.entity.tick.Tick
 import com.yessorae.domain.entity.trade.Trade
 import com.yessorae.domain.entity.value.Money
 
 data class ChartGame(
     val id: Long = 0,
-    // 차트 데이터
-    val chart: Chart,
-    // 거래 내역
-    val trades: List<Trade>,
+    // 게임에 종속된 차트의 id
+    val chartId: Long,
     // 현재 턴
     val currentTurn: Int,
     // 전체 턴
@@ -18,57 +15,19 @@ data class ChartGame(
     val startBalance: Money,
     // 현재 잔고
     val currentBalance: Money,
-    // 유저의 게임 강제 종료 여부
-    val isQuit: Boolean
-) {
-
-    private val sortedTicks = chart.ticks.sortedBy { it.startTimestamp }
-
-    private val lastVisibleIndex = (chart.ticks.size - 1) - (totalTurn - currentTurn)
-
-    // 현재 턴의까지의 차트 데이터
-    val visibleTicks: List<Tick> = if (chart.ticks.size <= lastVisibleIndex) {
-        sortedTicks
-    } else {
-        sortedTicks.subList(0, lastVisibleIndex)
-    }
-
-    // 보유 주식 수량
-    val ownedStockCount = trades.sumOf { trade ->
-        if (trade.type.isBuy()) {
-            trade.count
-        } else {
-            -trade.count
-        }
-    }
-
-    // 보유 주식 총 가치
-    private val ownedTotalStockPrice = trades.sumOf { trade ->
-        if (trade.type.isBuy()) {
-            trade.totalTradeMoney.value
-        } else {
-            -trade.totalTradeMoney.value
-        }
-    }
-
-    // 현재 보유 주식 평단가
-    val ownedAverageStockPrice = if (ownedStockCount != 0) {
-        Money(ownedTotalStockPrice / ownedStockCount)
-    } else {
-        Money(0.0)
-    }
-
     // 현재 종가
-    val currentClosePrice: Money = (visibleTicks.lastOrNull()?.closePrice ?: Money(0.0))
-
+    val closeStockPrice: Money,
+    // 유저의 게임 강제 종료 여부
+    val isQuit: Boolean,
+    // 현재 보유 주식 수량
+    val totalStockCount: Int,
+    // 현재 보유 주식 가격의 총합
+    val totalStockPrice: Money,
+    // 현재 보유 주식 평단가
+    val averageStockPrice: Money,
     // 누적 수익
-    val accumulatedTotalProfit: Money = trades.fold(Money(0.0)) { acc, trade ->
-        acc + trade.profit
-    } + if (ownedStockCount != 0) {
-        currentClosePrice - ownedAverageStockPrice
-    } else {
-        Money(0.0)
-    }
+    val accumulatedTotalProfit: Money,
+) {
 
     // 누적 수익률
     val accumulatedRateOfProfit: Double = (accumulatedTotalProfit / startBalance).value
@@ -89,19 +48,35 @@ data class ChartGame(
         )
     }
 
-    internal fun copyFrom(newChart: Chart): ChartGame {
-        return copy(
-            chart = newChart,
-            currentTurn = START_TURN,
-            trades = emptyList(),
-            currentBalance = startBalance
-        )
-    }
-
     internal fun copyFrom(newTrade: Trade): ChartGame {
+        val newTotalStockCount: Int = totalStockCount + if (newTrade.type.isBuy()) {
+            newTrade.count
+        } else {
+            -newTrade.count
+        }
+
         return copy(
-            trades = trades + newTrade,
-            currentBalance = currentBalance - newTrade.totalTradeMoney
+            currentBalance = currentBalance + Money.of(
+                if (newTrade.type.isBuy()) {
+                    -newTrade.totalTradeMoney.value
+                } else {
+                    newTrade.totalTradeMoney.value
+                }
+            ),
+            totalStockCount = newTotalStockCount,
+            totalStockPrice = totalStockPrice + Money.of(
+                if (newTrade.type.isBuy()) {
+                    newTrade.totalTradeMoney.value
+                } else {
+                    -newTrade.totalTradeMoney.value
+                }
+            ),
+            averageStockPrice = if (newTrade.type.isBuy()) {
+                (totalStockPrice + newTrade.totalTradeMoney) / newTotalStockCount
+            } else {
+                averageStockPrice
+            },
+            accumulatedTotalProfit = accumulatedTotalProfit + newTrade.profit
         )
     }
 
@@ -112,21 +87,26 @@ data class ChartGame(
     }
 
     companion object {
-        private const val START_TURN = 1
+        const val START_TURN = 1
 
         fun new(
-            chart: Chart,
+            chartId: Long,
             totalTurn: Int,
-            startBalance: Money
+            startBalance: Money,
+            closeStockPrice: Money,
         ): ChartGame {
             return ChartGame(
-                chart = chart,
-                trades = emptyList(),
+                chartId = chartId,
                 currentTurn = START_TURN,
                 totalTurn = totalTurn,
                 startBalance = startBalance,
                 currentBalance = startBalance,
-                isQuit = false
+                closeStockPrice = closeStockPrice,
+                isQuit = false,
+                totalStockCount = 0,
+                totalStockPrice = Money.ZERO,
+                averageStockPrice = Money.ZERO,
+                accumulatedTotalProfit = Money.ZERO
             )
         }
     }

--- a/domain/src/main/java/com/yessorae/domain/entity/ChartGame.kt
+++ b/domain/src/main/java/com/yessorae/domain/entity/ChartGame.kt
@@ -18,7 +18,7 @@ data class ChartGame(
     // 현재 종가
     val closeStockPrice: Money,
     // 유저의 게임 강제 종료 여부
-    val isQuit: Boolean,
+    val isQuit: Boolean, // TODO::NOW 쿼리할 때 isQuit 가 true인 것을 제외하고 가져오도록 수정 필요
     // 현재 보유 주식 수량
     val totalStockCount: Int,
     // 현재 보유 주식 가격의 총합
@@ -41,14 +41,14 @@ data class ChartGame(
     // 정상종료이든 강제종료이든 종료된 경우 true
     val isGameEnd: Boolean = isQuit || isGameComplete
 
-    internal fun getNextTurn(): ChartGame {
+    internal fun getNextTurnResult(): ChartGame {
         val nextTurn = currentTurn + 1
         return this.copy(
             currentTurn = nextTurn
         )
     }
 
-    internal fun copyFrom(newTrade: Trade): ChartGame {
+    internal fun getTradeResult(newTrade: Trade): ChartGame {
         val newTotalStockCount: Int = totalStockCount + if (newTrade.type.isBuy()) {
             newTrade.count
         } else {
@@ -80,7 +80,21 @@ data class ChartGame(
         )
     }
 
-    internal fun createFromQuit(): ChartGame {
+    internal fun getChartChangeResult(
+        closeStockPrice: Money
+    ): ChartGame {
+        return copy(
+            currentTurn = START_TURN,
+            currentBalance = startBalance,
+            closeStockPrice = closeStockPrice,
+            totalStockCount = 0,
+            totalStockPrice = Money.ZERO,
+            averageStockPrice = Money.ZERO,
+            accumulatedTotalProfit = Money.ZERO
+        )
+    }
+
+    internal fun getQuitResult(): ChartGame {
         return copy(
             isQuit = true
         )

--- a/domain/src/main/java/com/yessorae/domain/entity/User.kt
+++ b/domain/src/main/java/com/yessorae/domain/entity/User.kt
@@ -29,7 +29,7 @@ data class User(
 
     fun quiteGame(): User {
         return this.copy(
-            loseCount = loseCount + 1,
+            loseCount = loseCount + 1
         )
     }
 

--- a/domain/src/main/java/com/yessorae/domain/entity/User.kt
+++ b/domain/src/main/java/com/yessorae/domain/entity/User.kt
@@ -27,7 +27,13 @@ data class User(
         1 - rateOfWinning
     }
 
-    fun copyFrom(
+    fun quiteGame(): User {
+        return this.copy(
+            loseCount = loseCount + 1,
+        )
+    }
+
+    fun finishGame(
         profit: Double,
         rateOfProfit: Double
     ): User {

--- a/domain/src/main/java/com/yessorae/domain/entity/trade/Trade.kt
+++ b/domain/src/main/java/com/yessorae/domain/entity/trade/Trade.kt
@@ -28,7 +28,7 @@ data class Trade(
 
     // 실현 손익, 매도할 때만 유효
     val profit: Money = if (type.isBuy()) {
-        Money(0.0)
+        Money(0.0) // TODO::CT-52 버그 수정 필요. 도메인 모델 Unit Testing 브랜치에서 수정 예정.
     } else {
         ((stockPrice - ownedAverageStockPrice) * count) - commission
     }

--- a/domain/src/main/java/com/yessorae/domain/entity/value/Money.kt
+++ b/domain/src/main/java/com/yessorae/domain/entity/value/Money.kt
@@ -31,4 +31,19 @@ data class Money(
     operator fun div(other: Money): Money {
         return Money(value / other.value)
     }
+
+    operator fun div(other: Double): Money {
+        return Money(value / other)
+    }
+
+    operator fun div(other: Int): Money {
+        return Money(value / other)
+    }
+
+    companion object {
+        val ZERO = Money(0.0)
+        fun of(value: Double): Money {
+            return Money(value)
+        }
+    }
 }

--- a/domain/src/main/java/com/yessorae/domain/exception/ChartGameException.kt
+++ b/domain/src/main/java/com/yessorae/domain/exception/ChartGameException.kt
@@ -1,6 +1,10 @@
 package com.yessorae.domain.exception
 
 sealed class ChartGameException(override val message: String = "") : Exception(message) {
+    data class CanNotCreateChartGame(
+        override val message: String
+    ) : ChartGameException(message = message)
+
     data class CanNotChangeChartException(
         override val message: String
     ) : ChartGameException(message = message)

--- a/domain/src/main/java/com/yessorae/domain/repository/ChartGameRepository.kt
+++ b/domain/src/main/java/com/yessorae/domain/repository/ChartGameRepository.kt
@@ -21,4 +21,3 @@ interface ChartGameRepository {
     suspend fun clearLastChartGameId()
     suspend fun updateLastChartGameId(gameId: Long)
 }
-

--- a/domain/src/main/java/com/yessorae/domain/repository/ChartGameRepository.kt
+++ b/domain/src/main/java/com/yessorae/domain/repository/ChartGameRepository.kt
@@ -13,7 +13,6 @@ interface ChartGameRepository {
     fun fetchPagedChartGameFlow(pagingConfig: PagingConfig): Flow<PagingData<ChartGame>>
 
     suspend fun fetchChartGame(gameId: Long): ChartGame
-    suspend fun fetchChartId(gameId: Long): Long
 
     // TODO::NOW 호출하는 곳들 확인. 이제 Chart, List<Trade> 를 독립적으로 업데이트해야함
     suspend fun updateChartGame(chartGame: ChartGame)

--- a/domain/src/main/java/com/yessorae/domain/repository/ChartGameRepository.kt
+++ b/domain/src/main/java/com/yessorae/domain/repository/ChartGameRepository.kt
@@ -13,10 +13,13 @@ interface ChartGameRepository {
     fun fetchPagedChartGameFlow(pagingConfig: PagingConfig): Flow<PagingData<ChartGame>>
 
     suspend fun fetchChartGame(gameId: Long): ChartGame
+    suspend fun fetchChartId(gameId: Long): Long
 
+    // TODO::NOW 호출하는 곳들 확인. 이제 Chart, List<Trade> 를 독립적으로 업데이트해야함
     suspend fun updateChartGame(chartGame: ChartGame)
 
     fun fetchLastChartGameId(): Flow<Long?>
     suspend fun clearLastChartGameId()
     suspend fun updateLastChartGameId(gameId: Long)
 }
+

--- a/domain/src/main/java/com/yessorae/domain/repository/ChartRepository.kt
+++ b/domain/src/main/java/com/yessorae/domain/repository/ChartRepository.kt
@@ -4,4 +4,5 @@ import com.yessorae.domain.entity.Chart
 
 interface ChartRepository {
     suspend fun fetchNewChartRandomly(totalTurn: Int): Chart
+    suspend fun fetchChart(gameId: Long): Chart
 }

--- a/domain/src/main/java/com/yessorae/domain/repository/TradeRepository.kt
+++ b/domain/src/main/java/com/yessorae/domain/repository/TradeRepository.kt
@@ -6,5 +6,4 @@ import kotlinx.coroutines.flow.Flow
 interface TradeRepository {
     suspend fun fetchTrades(gameId: Long): List<Trade>
     suspend fun createTrade(trade: Trade): Long
-    suspend fun updateTrades(trades: List<Trade>)
 }

--- a/domain/src/main/java/com/yessorae/domain/repository/TradeRepository.kt
+++ b/domain/src/main/java/com/yessorae/domain/repository/TradeRepository.kt
@@ -1,7 +1,6 @@
 package com.yessorae.domain.repository
 
 import com.yessorae.domain.entity.trade.Trade
-import kotlinx.coroutines.flow.Flow
 
 interface TradeRepository {
     suspend fun fetchTrades(gameId: Long): List<Trade>

--- a/domain/src/main/java/com/yessorae/domain/repository/TradeRepository.kt
+++ b/domain/src/main/java/com/yessorae/domain/repository/TradeRepository.kt
@@ -1,0 +1,10 @@
+package com.yessorae.domain.repository
+
+import com.yessorae.domain.entity.trade.Trade
+import kotlinx.coroutines.flow.Flow
+
+interface TradeRepository {
+    suspend fun fetchTrades(gameId: Long): List<Trade>
+    suspend fun createTrade(trade: Trade): Long
+    suspend fun updateTrades(trades: List<Trade>)
+}

--- a/domain/src/main/java/com/yessorae/domain/usecase/ChangeChartUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/ChangeChartUseCase.kt
@@ -37,13 +37,10 @@ class ChangeChartUseCase @Inject constructor(
             }
             val closeStockPrice = newChart.ticks[totalTurn - 1].closePrice
 
+            val newChartGame = oldChartGame.getChartChangeResult(closeStockPrice = closeStockPrice)
+
             chartGameRepository.updateChartGame(
-                chartGame = ChartGame.new(
-                    chartId = newChart.id,
-                    totalTurn = totalTurn,
-                    startBalance = userRepository.fetchUser().balance,
-                    closeStockPrice = closeStockPrice
-                )
+                chartGame = newChartGame
             )
         }.delegateEmptyResultFlow()
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/ChangeChartUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/ChangeChartUseCase.kt
@@ -2,7 +2,6 @@ package com.yessorae.domain.usecase
 
 import com.yessorae.domain.common.Result
 import com.yessorae.domain.common.delegateEmptyResultFlow
-import com.yessorae.domain.entity.ChartGame
 import com.yessorae.domain.exception.ChartGameException
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.ChartRepository

--- a/domain/src/main/java/com/yessorae/domain/usecase/QuitChartGameUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/QuitChartGameUseCase.kt
@@ -2,9 +2,7 @@ package com.yessorae.domain.usecase
 
 import com.yessorae.domain.common.Result
 import com.yessorae.domain.common.delegateEmptyResultFlow
-import com.yessorae.domain.entity.User
 import com.yessorae.domain.repository.ChartGameRepository
-import com.yessorae.domain.repository.TradeRepository
 import com.yessorae.domain.repository.UserRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow

--- a/domain/src/main/java/com/yessorae/domain/usecase/QuitChartGameUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/QuitChartGameUseCase.kt
@@ -4,6 +4,7 @@ import com.yessorae.domain.common.Result
 import com.yessorae.domain.common.delegateEmptyResultFlow
 import com.yessorae.domain.entity.User
 import com.yessorae.domain.repository.ChartGameRepository
+import com.yessorae.domain.repository.TradeRepository
 import com.yessorae.domain.repository.UserRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -15,18 +16,10 @@ class QuitChartGameUseCase @Inject constructor(
 ) {
     operator fun invoke(gameId: Long): Flow<Result<Unit>> =
         flow<Nothing> {
-            val oldChartGame = chartGameRepository.fetchChartGame(gameId = gameId)
-            chartGameRepository.updateChartGame(chartGame = oldChartGame.createFromQuit())
-
-            chartGameRepository.clearLastChartGameId()
-
-            // Quit 하면 패배 처리
-            val oldUser: User = userRepository.fetchUser()
-            userRepository.updateUser(
-                oldUser.copyFrom(
-                    profit = oldChartGame.accumulatedTotalProfit.value,
-                    rateOfProfit = oldChartGame.accumulatedRateOfProfit
-                )
+            chartGameRepository.updateChartGame(
+                chartGame = chartGameRepository.fetchChartGame(gameId = gameId).getQuitResult()
             )
+            chartGameRepository.clearLastChartGameId()
+            userRepository.updateUser(user = userRepository.fetchUser().quiteGame())
         }.delegateEmptyResultFlow()
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameHistoryUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameHistoryUseCase.kt
@@ -2,23 +2,41 @@ package com.yessorae.domain.usecase
 
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import androidx.paging.map
+import com.yessorae.domain.entity.Chart
 import com.yessorae.domain.entity.ChartGame
 import com.yessorae.domain.repository.ChartGameRepository
+import com.yessorae.domain.repository.ChartRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class SubscribeChartGameHistoryUseCase @Inject constructor(
-    private val chartGameRepository: ChartGameRepository
+    private val chartGameRepository: ChartGameRepository,
+    private val chartRepository: ChartRepository
 ) {
-    operator fun invoke(): Flow<PagingData<ChartGame>> {
+    operator fun invoke(): Flow<PagingData<SuccessData>> {
         return chartGameRepository.fetchPagedChartGameFlow(
             pagingConfig = PagingConfig(
                 pageSize = PAGE_SIZE,
                 initialLoadSize = PAGE_SIZE,
                 enablePlaceholders = false
             )
-        )
+        ).map { pagingData ->
+            pagingData.map { chartGame ->
+                val chart = chartRepository.fetchChart(gameId = chartGame.id)
+                SuccessData(
+                    chartGame = chartGame,
+                    chart = chart
+                )
+            }
+        }
     }
+
+    data class SuccessData(
+        val chartGame: ChartGame,
+        val chart: Chart
+    )
 
     companion object {
         const val PAGE_SIZE = 20

--- a/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameUseCase.kt
@@ -8,9 +8,9 @@ import com.yessorae.domain.exception.ChartGameException.CanNotCreateChartGame
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.ChartRepository
 import com.yessorae.domain.repository.UserRepository
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 class SubscribeChartGameUseCase @Inject constructor(
     private val userRepository: UserRepository,
@@ -20,7 +20,6 @@ class SubscribeChartGameUseCase @Inject constructor(
     suspend operator fun invoke(gameId: Long?): Flow<Result<SuccessData>> {
         if (gameId != null) {
             val chart = chartRepository.fetchChart(gameId = gameId)
-
 
             return chartGameRepository
                 .fetchChartGameFlow(gameId = gameId)
@@ -40,7 +39,6 @@ class SubscribeChartGameUseCase @Inject constructor(
                 }
                 .delegateValueResultFlow()
         }
-
 
         val totalTurn = userRepository.fetchTotalTurn()
 

--- a/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/SubscribeChartGameUseCase.kt
@@ -3,38 +3,84 @@ package com.yessorae.domain.usecase
 import com.yessorae.domain.common.Result
 import com.yessorae.domain.common.delegateValueResultFlow
 import com.yessorae.domain.entity.ChartGame
+import com.yessorae.domain.entity.tick.Tick
+import com.yessorae.domain.exception.ChartGameException.CanNotCreateChartGame
 import com.yessorae.domain.repository.ChartGameRepository
 import com.yessorae.domain.repository.ChartRepository
 import com.yessorae.domain.repository.UserRepository
-import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
 
 class SubscribeChartGameUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val chartRepository: ChartRepository,
     private val chartGameRepository: ChartGameRepository
 ) {
-    suspend operator fun invoke(gameId: Long?): Flow<Result<ChartGame>> {
-        if (gameId == null) {
-            val totalTurn = userRepository.fetchTotalTurn()
+    suspend operator fun invoke(gameId: Long?): Flow<Result<SuccessData>> {
+        if (gameId != null) {
+            val chart = chartRepository.fetchChart(gameId = gameId)
 
-            val newGameId = chartGameRepository.createNewChartGame(
-                chartGame = ChartGame.new(
-                    chart = chartRepository.fetchNewChartRandomly(totalTurn = totalTurn),
-                    totalTurn = totalTurn,
-                    startBalance = userRepository.fetchUser().balance
-                )
-            )
-
-            chartGameRepository.updateLastChartGameId(gameId = newGameId)
 
             return chartGameRepository
-                .fetchChartGameFlow(gameId = newGameId)
+                .fetchChartGameFlow(gameId = gameId)
+                .map { chartGame ->
+                    val lastVisibleTickIndex =
+                        (chart.ticks.size - 1) - (chartGame.totalTurn - ChartGame.START_TURN)
+
+                    assert(value = lastVisibleTickIndex >= 0)
+
+                    SuccessData(
+                        chartGame = chartGame,
+                        visibleTicks = chart.ticks.subList(
+                            0,
+                            lastVisibleTickIndex
+                        )
+                    )
+                }
                 .delegateValueResultFlow()
         }
 
+
+        val totalTurn = userRepository.fetchTotalTurn()
+
+        val newChart = chartRepository.fetchNewChartRandomly(totalTurn = totalTurn)
+
+        val lastVisibleTickIndex = (newChart.ticks.size - 1) - (totalTurn - ChartGame.START_TURN)
+
+        if (lastVisibleTickIndex < 0) {
+            throw CanNotCreateChartGame(
+                message = "can't change chart because new chart has not enough ticks"
+            )
+        }
+
+        val newGameId = chartGameRepository.createNewChartGame(
+            chartGame = ChartGame.new(
+                chartId = newChart.id,
+                totalTurn = totalTurn,
+                startBalance = userRepository.fetchUser().balance,
+                closeStockPrice = newChart.ticks[lastVisibleTickIndex].closePrice
+            )
+        )
+
+        chartGameRepository.updateLastChartGameId(gameId = newGameId)
+
         return chartGameRepository
-            .fetchChartGameFlow(gameId = gameId)
+            .fetchChartGameFlow(gameId = newGameId)
+            .map { chartGame ->
+                SuccessData(
+                    chartGame = chartGame,
+                    visibleTicks = newChart.ticks.subList(
+                        fromIndex = 0,
+                        toIndex = lastVisibleTickIndex
+                    )
+                )
+            }
             .delegateValueResultFlow()
     }
+
+    data class SuccessData(
+        val chartGame: ChartGame,
+        val visibleTicks: List<Tick>
+    )
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/SubscribeTradeHistoryUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/SubscribeTradeHistoryUseCase.kt
@@ -3,14 +3,31 @@ package com.yessorae.domain.usecase
 import com.yessorae.domain.common.Result
 import com.yessorae.domain.common.delegateValueResultFlow
 import com.yessorae.domain.entity.ChartGame
+import com.yessorae.domain.entity.trade.Trade
 import com.yessorae.domain.repository.ChartGameRepository
+import com.yessorae.domain.repository.TradeRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class SubscribeTradeHistoryUseCase @Inject constructor(
-    private val chartGameRepository: ChartGameRepository
+    private val chartGameRepository: ChartGameRepository,
+    private val tradeRepository: TradeRepository
 ) {
-    operator fun invoke(gameId: Long): Flow<Result<ChartGame>> {
-        return chartGameRepository.fetchChartGameFlow(gameId = gameId).delegateValueResultFlow()
+    operator fun invoke(gameId: Long): Flow<Result<SuccessData>> {
+        return chartGameRepository
+            .fetchChartGameFlow(gameId = gameId)
+            .map { chartGame ->
+                SuccessData(
+                    chartGame = chartGame,
+                    trades = tradeRepository.fetchTrades(gameId = gameId)
+                )
+            }
+            .delegateValueResultFlow()
     }
+
+    data class SuccessData(
+        val chartGame: ChartGame,
+        val trades: List<Trade>
+    )
 }

--- a/domain/src/main/java/com/yessorae/domain/usecase/TradeStockUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/TradeStockUseCase.kt
@@ -6,6 +6,7 @@ import com.yessorae.domain.entity.trade.Trade
 import com.yessorae.domain.entity.trade.TradeType
 import com.yessorae.domain.entity.value.Money
 import com.yessorae.domain.repository.ChartGameRepository
+import com.yessorae.domain.repository.TradeRepository
 import com.yessorae.domain.repository.UserRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.flow
 
 class TradeStockUseCase @Inject constructor(
     private val chartGameRepository: ChartGameRepository,
+    private val tradeRepository: TradeRepository,
     private val userRepository: UserRepository
 ) {
     operator fun invoke(param: Param): Flow<Result<Unit>> =
@@ -27,14 +29,11 @@ class TradeStockUseCase @Inject constructor(
                     type = type,
                     commissionRate = userRepository.fetchCommissionRate()
                 )
+                tradeRepository.createTrade(trade = trade)
 
-                chartGameRepository.updateChartGame(
-                    chartGame = chartGameRepository.fetchChartGame(
-                        gameId = gameId
-                    ).copyFrom(
-                        newTrade = trade
-                    )
-                )
+                val oldChartGame = chartGameRepository.fetchChartGame(gameId = gameId)
+                val newChartGame = oldChartGame.getTradeResult(newTrade = trade)
+                chartGameRepository.updateChartGame(chartGame = newChartGame)
             }
         }.delegateEmptyResultFlow()
 

--- a/domain/src/main/java/com/yessorae/domain/usecase/UpdateNextTickUseCase.kt
+++ b/domain/src/main/java/com/yessorae/domain/usecase/UpdateNextTickUseCase.kt
@@ -24,12 +24,12 @@ class UpdateNextTickUseCase @Inject constructor(
                 )
             }
 
-            val newChartGame = oldChartGame.getNextTurn()
+            val newChartGame = oldChartGame.getNextTurnResult()
 
             if (newChartGame.isGameEnd) {
                 val oldUser: User = userRepository.fetchUser()
                 userRepository.updateUser(
-                    oldUser.copyFrom(
+                    oldUser.finishGame(
                         profit = newChartGame.accumulatedTotalProfit.value,
                         rateOfProfit = newChartGame.accumulatedRateOfProfit
                     )

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgame/ChartGameViewModel.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgame/ChartGameViewModel.kt
@@ -98,37 +98,36 @@ class ChartGameViewModel @Inject constructor(
     private fun updateGameData(
         chartGame: ChartGame,
         visibleTicks: List<Tick>
-    ) =
-        with(chartGame) {
-            _screenState.update { old ->
-                old.copy(
-                    currentTurn = currentTurn,
-                    totalTurn = totalTurn,
-                    totalProfit = accumulatedTotalProfit.value,
-                    rateOfProfit = accumulatedRateOfProfit,
-                    gameProgress = currentGameProgress,
-                    showLoading = false,
-                    candleStickChart = visibleTicks.asCandleStickChartUiState(),
-                    isGameComplete = isGameComplete,
-                    isGameEnd = isGameEnd,
-                    onUserAction = { userAction ->
-                        handleChartGameScreenUserAction(
-                            userAction = userAction,
-                            gameId = id,
-                            ownedAverageStockPrice = averageStockPrice,
-                            currentBalance = currentBalance,
-                            currentStockPrice = closeStockPrice,
-                            currentTurn = currentTurn,
-                            ownedStockCount = totalStockCount
-                        )
-                    }
-                )
-            }
-
-            if (isGameComplete) {
-                emitScreenEvent(event = ChartGameEvent.GameHasEnded(gameId = id))
-            }
+    ) = with(chartGame) {
+        _screenState.update { old ->
+            old.copy(
+                currentTurn = currentTurn,
+                totalTurn = totalTurn,
+                totalProfit = accumulatedTotalProfit.value,
+                rateOfProfit = accumulatedRateOfProfit,
+                gameProgress = currentGameProgress,
+                showLoading = false,
+                candleStickChart = visibleTicks.asCandleStickChartUiState(),
+                isGameComplete = isGameComplete,
+                isGameEnd = isGameEnd,
+                onUserAction = { userAction ->
+                    handleChartGameScreenUserAction(
+                        userAction = userAction,
+                        gameId = id,
+                        ownedAverageStockPrice = averageStockPrice,
+                        currentBalance = currentBalance,
+                        currentStockPrice = closeStockPrice,
+                        currentTurn = currentTurn,
+                        ownedStockCount = totalStockCount
+                    )
+                }
+            )
         }
+
+        if (isGameComplete) {
+            emitScreenEvent(event = ChartGameEvent.GameHasEnded(gameId = id))
+        }
+    }
 
     private fun handleChartGameScreenUserAction(
         userAction: ChartGameScreenUserAction,

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryViewModel.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/chartgamehistory/ChartGameHistoryViewModel.kt
@@ -23,18 +23,20 @@ class ChartGameHistoryViewModel @Inject constructor(
     val pagedChartGameFlow =
         subscribeChartGameHistoryUseCase()
             .map { pagingData ->
-                pagingData.map { chartGame ->
+                pagingData.map { data ->
 
-                    GameHistoryItem(
-                        id = chartGame.id,
-                        ticker = chartGame.chart.tickerSymbol,
-                        totalTurn = chartGame.totalTurn,
-                        tickUnit = chartGame.chart.tickUnit,
-                        totalProfit = chartGame.accumulatedTotalProfit,
-                        isTotalProfitPositive = chartGame.accumulatedTotalProfit.value > 0.0,
-                        startDate = chartGame.chart.startDateTime,
-                        endDate = chartGame.chart.endDateTime
-                    )
+                    with(data) {
+                        GameHistoryItem(
+                            id = chartGame.id,
+                            ticker = chart.tickerSymbol,
+                            totalTurn = chartGame.totalTurn,
+                            tickUnit = chart.tickUnit,
+                            totalProfit = chartGame.accumulatedTotalProfit,
+                            isTotalProfitPositive = chartGame.accumulatedTotalProfit.value > 0.0,
+                            startDate = chart.startDateTime,
+                            endDate = chart.endDateTime
+                        )
+                    }
                 }
             }
             .cachedIn(viewModelScope)

--- a/presentation/src/main/java/com/yessorae/presentation/ui/screen/tradehistory/TradeHistoryViewModel.kt
+++ b/presentation/src/main/java/com/yessorae/presentation/ui/screen/tradehistory/TradeHistoryViewModel.kt
@@ -70,7 +70,7 @@ class TradeHistoryViewModel @Inject constructor(
 
                     is Result.Success -> {
                         _tradeHistoryScreen.value = TradeHistoryScreenModel(
-                            totalTurn = result.data.totalTurn,
+                            totalTurn = result.data.chartGame.totalTurn,
                             tradeHistories = result.data.trades.map(
                                 transform = Trade::asTradeHistoryListItemModel
                             ),


### PR DESCRIPTION
# Overview
- #53 의 셀프리뷰에서 언급한 내용입니다.
  - 개요
    - 현재 ChartGame 하나를 만들기 위해 Chart(그 안의 Tick), Trade 총 3개의 도메인 모델을 호출하고 있는데 이를 아래 두 가지 개선을 위해 분리할까 합니다.
    - ChartGame 도메인 모델에서는 Chart 객체 대신 chartId 를 가지고,
    -  Trade도 마찬가지로 ChartGame 에서 제거하고, 수익률을 Trade를 통해서 계산하는 게 아니라 매매가 일어나면 수익률을 수정하는 방식으로 수정하려고 합니다. (처음 생각에는 한 게임 내에 트레이드 수가 많지 않을 거라 생각해서 Trade리스트로부터 계산한 값을 사용했었습니다..)
  - 개선지점
    - 성능 개선
      - 불필요한 쿼리가 줄어듭니다. 예를 들어 Chart 데이터와 일부의 ChartGame 필드가 필요한데 모든 Trade를 조회해야할 필요가 없습니다.
    - 생성과정이 Repository 에 있는 점 개선
      - 현재 ChartGame 안에 있는 Chart와 Tick, Trade 를 떼어내면 자연스럽게 UseCase 에서 데이터를 조합하는 과정이 옮겨지는 효과가 있습니다.
      - 지금 data레이어의 Repository 구현체에서 ChartGame 모델을 만들 때, 만드는 과정이 함수로 따로 뗄정도로 복잡해서져서, domain 레이어 쪽으로 옳기고 싶다는 생각이었습니다.
